### PR TITLE
Additions for 4b2tau anaysis

### DIFF
--- a/python/helpers/FastMTT_cc/FastMTT.cc
+++ b/python/helpers/FastMTT_cc/FastMTT.cc
@@ -1,0 +1,465 @@
+#include <algorithm>
+
+#include "Math/Minimizer.h"
+#include "Math/Factory.h"
+#include "Math/Functor.h"
+
+#include "TMath.h"
+#include "TVector2.h"
+#include "TMatrixD.h"
+
+#include "TF1.h"
+#include "Math/BasicMinimizer.h"
+
+#include "FastMTT.h"
+#include "MeasuredTauLepton.h"
+
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+Likelihood::Likelihood(){
+
+  covMET.ResizeTo(2,2);
+
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+Likelihood::~Likelihood(){}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+void Likelihood::setLeptonInputs(const LorentzVector & aLeg1P4,
+                                 const LorentzVector & aLeg2P4,
+                                 int aLeg1DecayType, int aLeg2DecayType,
+				 int aLeg1DecayMode, int aLeg2DecayMode){
+  leg1P4 = aLeg1P4;
+  leg2P4 = aLeg2P4;
+
+  mVis = (leg1P4 + leg2P4).M();
+  mVisLeg1 = leg1P4.M();
+  mVisLeg2 = leg2P4.M();
+ 
+  if(aLeg1DecayType==classic_svFit::MeasuredTauLepton::kTauToHadDecay && mVisLeg1>1.5){
+    mVisLeg1 = 0.3;
+  }  
+  if(aLeg2DecayType==classic_svFit::MeasuredTauLepton::kTauToHadDecay && mVisLeg2>1.5){
+    mVisLeg2 = 0.3;
+  }
+
+  leg1DecayType = aLeg1DecayType;
+  leg2DecayType = aLeg2DecayType;
+
+  leg1DecayMode = aLeg1DecayMode;
+  leg2DecayMode = aLeg2DecayMode;
+  
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+void Likelihood::setMETInputs(const LorentzVector & aMET,
+                              const TMatrixD& aCovMET){
+  recoMET = aMET;
+  covMET = aCovMET;
+
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+void Likelihood::setParameters(const std::vector<double> & aPars){
+
+  parameters = aPars;
+
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+double Likelihood::massLikelihood(const double & m) const{
+
+  double coeff1 = parameters[0];
+  double coeff2 = parameters[1];
+  double mShift = m*coeff2;
+
+  if(mShift<mVis) return 0.0;
+
+  const double & mTau = classic_svFit::tauLeptonMass;
+
+  double x1Min = std::min(1.0, std::pow(mVisLeg1/mTau,2));
+  double x2Min = std::max(std::pow(mVisLeg2/mTau,2), std::pow(mVis/mShift,2));
+  double x2Max = std::min(1.0, std::pow(mVis/mShift,2)/x1Min);
+  if(x2Max<x2Min) return 0.0;
+
+  double jacobiFactor = 2.0*std::pow(mVis,2)*std::pow(mShift,-coeff1);
+  double x2IntegralTerm = log(x2Max)-log(x2Min);
+    
+  double value = x2IntegralTerm;
+  if(leg1DecayType!=classic_svFit::MeasuredTauLepton::kTauToHadDecay){
+    double mNuNuIntegralTermLeg1 = std::pow(mVis/mShift,2)*(std::pow(x2Max,-1) - std::pow(x2Min,-1));
+    value += mNuNuIntegralTermLeg1;
+  }
+  if(leg2DecayType!=classic_svFit::MeasuredTauLepton::kTauToHadDecay){
+    double mNuNuIntegralTermLeg2 = std::pow(mVis/mShift,2)*x2IntegralTerm - (x2Max - x2Min);
+    value += mNuNuIntegralTermLeg2;
+  }
+    
+  ///The E9 factor to get values around 1.0
+  value *=  1E9*jacobiFactor;
+  
+  return value;
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+double Likelihood::ptLikelihood(const double & pTTauTau, int type) const{
+
+  ///Protection against numerical singularity in phase space volume.
+  if(std::abs(pTTauTau)<0.5) return 0.0;
+
+  const double & mTau = classic_svFit::tauLeptonMass;
+  double pT1 = 0.0;
+  double pT2 = 0.0;
+
+  if(type==0){
+    pT1 = leg1P4.Px();
+    pT2 = leg2P4.Px();    
+  }
+  else if(type==1){
+    pT1 = leg1P4.Py();
+    pT2 = leg2P4.Py();
+  }
+  else{
+    pT1 = leg1P4.Pz();
+    pT2 = leg2P4.Pz();
+  }
+
+  Double_t x1Min = std::min(1.0, std::pow(mVisLeg1/mTau,2));
+  Double_t x2Min = std::min(1.0, std::pow(mVisLeg2/mTau,2));
+
+   Double_t x2Max = 1.0;
+   Double_t x1Max = 1.0;
+
+   Double_t a_x2 = x1Min*pT2/(x1Min*pTTauTau - pT1);
+   Double_t b_x2 = x1Max*pT2/(x1Max*pTTauTau - pT1);
+
+   bool is_x1_vs_x2_falling = (-pT2*pT1)<0;
+   bool x2_vs_x1_hasSingularity = pT1/pTTauTau>0.0 &&  pT1/pTTauTau<1.0;
+   double x1_singularity = pT1/pTTauTau;
+   if(x2_vs_x1_hasSingularity && x1_singularity<x1Min) return 0.0;
+
+
+   if(is_x1_vs_x2_falling){
+     x2Min = std::max(x2Min, b_x2);
+     x2Max = std::min(x2Max, a_x2);
+     if(x2_vs_x1_hasSingularity && x2Max<0) x2Max = 1.0;
+   }
+   else{
+     x2Min = std::max(x2Min, a_x2);
+     x2Max = std::min(x2Max, b_x2);
+     if(x2_vs_x1_hasSingularity && x2Max<0) x2Max = 1.0;
+   }
+
+   if(x2Min<0) x2Min = 0.0;
+   if(x2Min>x2Max) return 0.0;
+
+  Double_t mNuNuIntegral = 0.0;
+  Double_t x2 = std::min(1.0, x2Max);
+
+  Double_t term1 = pT2-pTTauTau*x2;
+  Double_t log_term1 = log(std::abs(term1));
+  
+  Double_t integralMax = (pT1*(pTTauTau*x2+pow(pT2,2)/term1+2*pT2*log_term1))/pow(pTTauTau,3);
+  if(leg1DecayType!=classic_svFit::MeasuredTauLepton::kTauToHadDecay){
+    mNuNuIntegral =  -pow(pT1,2)*(2*pTTauTau*x2 + (pow(pT2,2)*(5*pT2 - 6*pTTauTau*x2))/pow(term1,2) +
+				  6*pT2*log_term1)/(2*pow(pTTauTau,4));
+  }
+  if(leg2DecayType!=classic_svFit::MeasuredTauLepton::kTauToHadDecay){
+    mNuNuIntegral += -pT1/(2*pow(pTTauTau,5))*
+                     (2*pT2*pTTauTau*(-3*pT1 + 2*pTTauTau)*x2 + 
+		      pow(pTTauTau,2)*(-pT1 + pTTauTau)*pow(x2,2) +
+		      (pow(pT2,4)*pT1)/pow(term1,2) + (2*pow(pT2,3)*(-4*pT1 + pTTauTau))/term1 + 
+		      6*pow(pT2,2)*(-2*pT1 + pTTauTau)*log_term1); 
+    }
+  integralMax += mNuNuIntegral;
+  
+  x2 = x2Min;
+  term1 = pT2-pTTauTau*x2;
+  log_term1 = log(std::abs(term1));
+  
+  Double_t integralMin = (pT1*(pTTauTau*x2+pow(pT2,2)/term1+2*pT2*log_term1))/pow(pTTauTau,3);
+  if(leg1DecayType!=classic_svFit::MeasuredTauLepton::kTauToHadDecay){
+    mNuNuIntegral =  -pow(pT1,2)*(2*pTTauTau*x2 + (pow(pT2,2)*(5*pT2 - 6*pTTauTau*x2))/pow(term1,2) +
+				  6*pT2*log_term1)/(2*pow(pTTauTau,4));
+  }
+  if(leg2DecayType!=classic_svFit::MeasuredTauLepton::kTauToHadDecay){
+  mNuNuIntegral += -pT1/(2*pow(pTTauTau,5))*
+                   (2*pT2*pTTauTau*(-3*pT1 + 2*pTTauTau)*x2 + 
+		    pow(pTTauTau,2)*(-pT1 + pTTauTau)*pow(x2,2) +
+		    (pow(pT2,4)*pT1)/pow(term1,2) + (2*pow(pT2,3)*(-4*pT1 + pTTauTau))/term1 + 
+		    6*pow(pT2,2)*(-2*pT1 + pTTauTau)*log_term1);  
+  }
+
+  integralMin += mNuNuIntegral;
+
+  Double_t value  = integralMax - integralMin;
+
+  ///The 1E4 factor to get values around 1.0
+  value *= 1E4;
+
+  return std::abs(value);
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////x
+double Likelihood::metTF(const LorentzVector & metP4,
+                         const LorentzVector & nuP4,
+                         const TMatrixD& covMET) const{
+
+  double  aMETx = metP4.X();
+  double  aMETy = metP4.Y();
+
+  double invCovMETxx = covMET(1,1);
+  double invCovMETxy = -covMET(0,1);
+  double invCovMETyx = -covMET(1,0);
+  double invCovMETyy = covMET(0,0);
+  double covDet = invCovMETxx*invCovMETyy - invCovMETxy*invCovMETyx;
+
+  if( std::abs(covDet)<1E-10){
+    std::cerr << "Error: Cannot invert MET covariance Matrix (det=0) !!"
+	      <<"METx: "<<aMETy<<" METy: "<<aMETy
+	      << std::endl;
+    return 0;
+  }
+  double const_MET = 1./(2.*M_PI*TMath::Sqrt(covDet));
+  double residualX = aMETx - (nuP4.X());
+  double residualY = aMETy - (nuP4.Y());
+
+  double pull2 = residualX*(invCovMETxx*residualX + invCovMETxy*residualY) +
+    residualY*(invCovMETyx*residualX + invCovMETyy*residualY);
+  pull2/=covDet;
+
+  return const_MET*TMath::Exp(-0.5*pull2);
+}
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+double Likelihood::value(const double *x) const{
+
+  const double & mTau = classic_svFit::tauLeptonMass;
+  double x1Min = std::min(1.0, std::pow(mVisLeg1/mTau,2));
+  double x2Min = std::min(1.0, std::pow(mVisLeg2/mTau,2));
+  if(x[0]<x1Min || x[1]<x2Min) return 0.0;
+  
+  testP4 = leg1P4*(1.0/x[0]) + leg2P4*(1.0/x[1]);
+  testMET = testP4 - leg1P4 - leg2P4;
+
+  double metLH = metTF(recoMET, testMET, covMET);
+  double massLH = massLikelihood(testP4.M());
+  double pxLH = ptLikelihood(testP4.Px(), 0);
+  double pyLH = ptLikelihood(testP4.Py(), 1);
+  
+  double value = -metLH*massLH*pxLH*pyLH;
+  
+  return value;
+}
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+FastMTT::FastMTT(){
+
+  minimizerName = "Minuit2";
+  minimizerAlgorithm = "Migrad";
+  initialize();
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+FastMTT::~FastMTT(){
+
+  delete minimizer;
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+void FastMTT::initialize(){
+
+  minimizer = ROOT::Math::Factory::CreateMinimizer(minimizerName, minimizerAlgorithm);
+  minimizer->SetMaxFunctionCalls(100000);
+  minimizer->SetMaxIterations(100000);
+  minimizer->SetTolerance(0.01);
+
+  std::vector<std::string> varNames = {"x1", "x2"};
+  nVariables = varNames.size();
+  std::vector<double> initialValues(nVariables,0.5);
+  std::vector<double> stepSizes(nVariables, 0.01);
+  minimumPosition = initialValues;
+  minimumValue = 999.0;
+
+  for(unsigned int iVar=0; iVar<nVariables; ++iVar){
+    minimizer->SetVariable(iVar, varNames[iVar].c_str(), initialValues[iVar], stepSizes[iVar]);
+  }
+
+  std::vector<double> shapeParams = {6, 1.0/1.15};
+  setLikelihoodParams(shapeParams);
+  likelihoodFunctor = new ROOT::Math::Functor(&myLikelihood, &Likelihood::value, nVariables);
+  minimizer->SetFunction(*likelihoodFunctor);
+
+  verbosity = 0;
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+void FastMTT::setLikelihoodParams(const std::vector<double> & aPars){
+
+   myLikelihood.setParameters(aPars);
+
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+bool FastMTT::compareLeptons(const classic_svFit::MeasuredTauLepton& measuredTauLepton1,
+			     const classic_svFit::MeasuredTauLepton& measuredTauLepton2){
+
+  using namespace classic_svFit;
+  
+  if ( (measuredTauLepton1.type() == MeasuredTauLepton::kTauToElecDecay || measuredTauLepton1.type() == MeasuredTauLepton::kTauToMuDecay) &&
+       measuredTauLepton2.type() == MeasuredTauLepton::kTauToHadDecay  ) return true;
+  if ( (measuredTauLepton2.type() == MeasuredTauLepton::kTauToElecDecay || measuredTauLepton2.type() == MeasuredTauLepton::kTauToMuDecay) &&
+       measuredTauLepton1.type() == MeasuredTauLepton::kTauToHadDecay ) return false;
+  return ( measuredTauLepton1.pt() > measuredTauLepton2.pt() );
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+void FastMTT::run(const std::vector<classic_svFit::MeasuredTauLepton>& measuredTauLeptons,
+		  const double & measuredMETx, const double & measuredMETy,
+		  const TMatrixD& covMET){
+
+  bestP4 = LorentzVector();  
+  ////////////////////////////////////////////
+  
+  if(measuredTauLeptons.size()!=2){
+    std::cout<<"Number of MeasuredTauLepton is "<<measuredTauLeptons.size()
+	     <<" a user shouls pass exactly two leptons."<<std::endl;
+    return;
+  }
+
+  std::vector<classic_svFit::MeasuredTauLepton> sortedMeasuredTauLeptons = measuredTauLeptons; 
+  std::sort(sortedMeasuredTauLeptons.begin(),
+  	    sortedMeasuredTauLeptons.end(),
+  	    compareLeptons);
+ 
+  double metLength = sqrt(std::pow(measuredMETx, 2) +
+			  std::pow(measuredMETy, 2));
+  LorentzVector aMET =  LorentzVector(measuredMETx, measuredMETy, 0, metLength);
+
+
+  const classic_svFit::MeasuredTauLepton & aLepton1 = measuredTauLeptons[0];
+  const classic_svFit::MeasuredTauLepton & aLepton2 = measuredTauLeptons[1];
+
+  myLikelihood.setLeptonInputs(aLepton1.p4(), aLepton2.p4(),
+			       aLepton1.type(), aLepton2.type(),
+			       aLepton1.decayMode(), aLepton2.decayMode());
+ 
+  myLikelihood.setMETInputs(aMET, covMET);
+
+  scan();
+  //minimize();
+
+  tau1P4 = aLepton1.p4()*(1.0/minimumPosition[0]);
+  tau2P4 = aLepton2.p4()*(1.0/minimumPosition[1]);
+
+  bestP4 = tau1P4 + tau2P4;
+  if(aLepton1.type() != classic_svFit::MeasuredTauLepton::kTauToHadDecay ||
+     aLepton2.type() != classic_svFit::MeasuredTauLepton::kTauToHadDecay){
+    bestP4 *= 1.03;
+   }
+  if(aLepton1.type() == classic_svFit::MeasuredTauLepton::kTauToHadDecay &&
+     aLepton2.type() == classic_svFit::MeasuredTauLepton::kTauToHadDecay){
+    bestP4 *= 0.98;
+  }
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+void FastMTT::minimize(){
+
+  clock.Reset();
+  clock.Start("minimize");
+
+  minimizer->SetVariableLimits(0, 0.01, 1.0);
+  minimizer->SetVariableLimits(1, 0.01, 1.0);
+
+  minimizer->SetVariable(0, "x1", 0.5, 0.1);
+  minimizer->SetVariable(1, "x2", 0.5, 0.1);
+    
+  minimizer->Minimize();
+
+  const double *theMinimum = minimizer->X();
+  minimumPosition[0] = theMinimum[0];
+  minimumPosition[1] = theMinimum[1];
+  minimumValue = minimizer->MinValue();
+
+   if(minimizer->Status()!=0){
+     std::cout<<" minimizer "
+	      <<" Status: "<<minimizer->Status()
+	      <<" nCalls: "<<minimizer->NCalls()
+	      <<" nIterations: "<<minimizer->NIterations()
+	      <<" x1Max: "<<theMinimum[0]
+	      <<" x2Max: "<<theMinimum[1]
+	      <<" max LLH: "<<minimizer->MinValue()
+	      <<" m: "<<bestP4.M()
+	      <<std::endl;
+}
+  clock.Stop("minimize");
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+void FastMTT::scan(){
+
+  clock.Reset();
+  clock.Start("scan");
+
+  double lh = 0.0;
+  double bestLH = 0.0;
+
+  double x[2] = {0.5, 0.5};
+  double theMinimum[2] = {0.75, 0.75};  
+  int nGridPoints = 100;
+  int nCalls = 0;
+  for(int iX2 = 1; iX2<nGridPoints;++iX2){
+    x[1] = 1.0*(double)iX2/nGridPoints;
+    for(int iX1 = 1; iX1<nGridPoints;++iX1){
+      x[0] = 1.0*(double)iX1/nGridPoints;
+
+      lh = myLikelihood.value(x);
+
+      ++nCalls;
+      if(lh<bestLH){
+	bestLH = lh;
+	theMinimum[0] = x[0];
+	theMinimum[1] = x[1];
+      }
+    }
+  }
+  
+  minimumPosition[0] = theMinimum[0];
+  minimumPosition[1] = theMinimum[1];
+  minimumValue = bestLH;
+
+  clock.Stop("scan");
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+double FastMTT::getCpuTime(const std::string & method){
+
+  return clock.GetCpuTime(method.c_str());
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+double FastMTT::getRealTime(const std::string & method){
+
+  return clock.GetRealTime(method.c_str());
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+std::tuple<double, double> FastMTT::getBestX() const{
+
+  return std::make_tuple(minimumPosition[0], minimumPosition[1]);
+  
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
+double FastMTT::getBestLikelihood() const{
+
+  return minimumValue;
+  
+}
+///////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////

--- a/python/helpers/FastMTT_cc/FastMTT.h
+++ b/python/helpers/FastMTT_cc/FastMTT.h
@@ -1,0 +1,186 @@
+#ifndef FastMTT_FastMTT_H
+#define FastMTT_FastMTT_H
+
+#include <string>
+#include <vector>
+#include <tuple>
+
+namespace classic_svFit{
+  class MeasuredTauLepton;
+}
+
+namespace ROOT{
+  namespace Math{
+    class Minimizer;
+    class Functor;
+  }
+}
+class TF1;
+class TVector2;
+
+#include "TMatrixD.h"
+#include "TBenchmark.h"
+#include "Math/LorentzVector.h"
+
+typedef ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > LorentzVector;
+
+namespace fastMTT {
+  double likelihoodFunc(double *x, double *par);
+}
+
+class Likelihood{
+
+public:
+
+  Likelihood();
+
+  ~Likelihood();
+
+  double value(const double *x) const;
+
+  void setLeptonInputs(const LorentzVector & aLeg1P4,
+                       const LorentzVector & aLeg2P4,
+                       int aLeg1DecayType, int aLeg2DecayType,
+		       int aLeg1DecayMode, int aLeg2DecayMode);
+  
+  void setMETInputs(const LorentzVector & aMET,
+                    const TMatrixD& aCovMET);
+
+  void setParameters(const std::vector<double> & parameters);
+
+  double massLikelihood(const double & m) const;
+
+  double ptLikelihood(const double & pTTauTau, int type) const;
+
+  double metTF(const LorentzVector & metP4,
+               const LorentzVector & nuP4,
+               const TMatrixD& covMET) const;
+
+private:
+
+  std::tuple<double, double> energyFromCosGJ(const LorentzVector & visP4,
+					     const double & cosGJ) const;
+
+
+  LorentzVector leg1P4, leg2P4;
+  LorentzVector recoMET;
+  mutable LorentzVector testP4, testMET;
+  
+  TMatrixD covMET;
+
+  double mVis, mVisLeg1, mVisLeg2;
+  
+  int leg1DecayType, leg2DecayType;
+  int leg1DecayMode, leg2DecayMode;
+
+  std::vector<double> parameters;
+
+};
+//////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////
+class FastMTT {
+
+ public:
+
+  FastMTT();
+
+  ~FastMTT();
+
+  void initialize();
+
+  ///Run fastMTT algorithm for given input
+  void run(const std::vector<classic_svFit::MeasuredTauLepton>&,
+	   const double &, const double &, const TMatrixD&);
+
+  ///Set likelihood shape parameters.
+  void setLikelihoodParams(const std::vector<double> & aPars);
+
+  ///Retrieve the four momentum corresponding to the likelihood maximum
+  const LorentzVector & getBestP4() const { return bestP4; }
+
+  ///Retrieve the tau1 four momentum corresponding to the likelihood maximum
+  const LorentzVector & getTau1P4() const { return tau1P4; }
+
+  ///Retrieve the tau1 four momentum corresponding to the likelihood maximum
+  const LorentzVector & getTau2P4() const { return tau2P4; }
+
+  ///Retrieve x values corresponding to the likelihood maximim
+  std::tuple<double, double> getBestX() const;
+
+  ///Retrieve the best likelihood value
+  double getBestLikelihood() const;
+  
+  ///Retrieve the CPU timing for given methods
+  ///Possible values:
+  /// scan
+  /// minimize
+  double getCpuTime(const std::string & method);
+
+  ///Retrieve the CPU timing for given methods
+  ///Possible values:
+  /// scan
+  /// minimize
+  double getRealTime(const std::string & method);
+
+ private:
+
+  static bool compareLeptons(const classic_svFit::MeasuredTauLepton& measuredTauLepton1,
+			     const classic_svFit::MeasuredTauLepton& measuredTauLepton2);
+  
+
+  ///Run the minimalization procedure for given inputs.
+  ///Results are stored in internal variables accesed by
+  ///relevant get methods.
+  void minimize();
+
+  ///Run a scan over x1 and x2 [0,1] rectangle for given inputs.
+  ///Results are stored in internal variables accesed by
+  ///relevant get methods.
+  void scan();
+
+   // Minimizer types and algorithms.
+   // minimizerName               minimizerAlgorithm
+   // Minuit /Minuit2             Migrad, Simplex,Combined,Scan  (default is Migrad)
+   //  Minuit2                     Fumili2
+   //  Fumili
+   //  GSLMultiMin                ConjugateFR, ConjugatePR, BFGS,
+   //                              BFGS2, SteepestDescent
+   //  GSLMultiFit
+   //   GSLSimAn
+   //   Genetic
+   std::string minimizerName;
+   std::string  minimizerAlgorithm;
+
+   ROOT::Math::Minimizer* minimizer;
+
+   ///Minimum location
+   std::vector<double> minimumPosition;
+
+   ///Mimimum value
+   double minimumValue;
+
+  ///Dimenstion of minimalization space
+  unsigned int nVariables;
+
+  ///Names of variables to be minimized
+  std::vector<std::string> varNames;
+
+  ///Values of variables to be minimized
+  std::vector<double> variables;
+
+  ///Step sizes for each minimized variable
+  std::vector<double> stepSizes;
+
+  ROOT::Math::Functor *likelihoodFunctor;
+
+  Likelihood myLikelihood;
+
+  LorentzVector tau1P4, tau2P4, bestP4;
+
+  TBenchmark clock;
+
+  int verbosity;
+
+};
+
+#endif

--- a/python/helpers/FastMTT_cc/MeasuredTauLepton.cc
+++ b/python/helpers/FastMTT_cc/MeasuredTauLepton.cc
@@ -1,0 +1,132 @@
+#include "MeasuredTauLepton.h"
+#include "svFitAuxFunctions.h"
+
+#include <TMath.h>
+
+using namespace classic_svFit;
+
+MeasuredTauLepton::MeasuredTauLepton()
+  : type_(kUndefinedDecayType),
+    pt_(0.),
+    eta_(0.),
+    phi_(0.),
+    mass_(0.),
+    decayMode_(-1)
+{
+  initialize();
+}
+
+MeasuredTauLepton::MeasuredTauLepton(int type, double pt, double eta, double phi, double mass, int decayMode)
+  : type_(type),
+    pt_(pt),
+    eta_(eta),
+    phi_(phi),
+    mass_(mass),
+    decayMode_(decayMode)
+{
+  //std::cout << "<MeasuredTauLepton>:" << std::endl;
+  //std::cout << " Pt = " << pt_ << ", eta = " << eta_ << ", phi = " << phi_ << ", mass = " << mass_ << std::endl;
+  double minVisMass = electronMass;
+  double maxVisMass = tauLeptonMass;
+  std::string type_string;
+  if ( type_ == kTauToElecDecay ) {
+    minVisMass = electronMass;
+    maxVisMass = minVisMass;
+  } else if ( type_ == kTauToMuDecay ) {
+    minVisMass = muonMass;
+    maxVisMass = minVisMass;
+  } else if ( type_ == kTauToHadDecay ) {
+    if ( decayMode_ == -1 ) {
+      minVisMass = chargedPionMass;
+      maxVisMass = 1.5;
+    } else if ( decayMode_ == 0 ) {
+      minVisMass = chargedPionMass;
+      maxVisMass = minVisMass;
+    } else {
+      minVisMass = 0.3;
+      maxVisMass = 1.5;
+    }
+  }
+  preciseVisMass_ = mass_;
+  if ( preciseVisMass_ < (0.9*minVisMass) || preciseVisMass_ > (1.1*maxVisMass) ) {
+    std::string type_string;
+    if      ( type_ == kTauToElecDecay ) type_string = "tau -> electron decay";
+    else if ( type_ == kTauToMuDecay   ) type_string = "tau -> muon decay";
+    else if ( type_ == kTauToHadDecay  ) type_string = "tau -> had decay";
+    else {
+      std::cerr << "Error: Invalid type " << type_ << " declared for leg: Pt = " << pt_ << ", eta = " << eta_ << ", phi = " << phi_ << ", mass = " << mass_ << " !!" << std::endl;
+      assert(0);
+    }
+    std::cerr << "Warning: " << type_string << " declared for leg: Pt = " << pt_ << ", eta = " << eta_ << ", phi = " << phi_ << ", mass = " << mass_ << " !!" << std::endl;
+    std::cerr << " (mass expected in the range = " << minVisMass << ".." << maxVisMass << ")" << std::endl;
+  }
+  if ( preciseVisMass_ < minVisMass ) preciseVisMass_ = minVisMass;
+  if ( preciseVisMass_ > maxVisMass ) preciseVisMass_ = maxVisMass;
+  initialize();
+  //std::cout << " En = " << energy_ << ", Px = " << px_ << ", Py = " << py_ << ", Pz = " << pz_ << std::endl;
+}
+
+MeasuredTauLepton::MeasuredTauLepton(const MeasuredTauLepton& measuredTauLepton)
+  : type_(measuredTauLepton.type()),
+    pt_(measuredTauLepton.pt()),
+    eta_(measuredTauLepton.eta()),
+    phi_(measuredTauLepton.phi()),
+    mass_(measuredTauLepton.mass()),
+    decayMode_(measuredTauLepton.decayMode())
+{
+  preciseVisMass_ = measuredTauLepton.mass();
+  initialize();
+}
+
+MeasuredTauLepton::~MeasuredTauLepton()
+{
+}
+
+int MeasuredTauLepton::type() const { return type_; }
+
+double MeasuredTauLepton::pt() const { return pt_; }
+double MeasuredTauLepton::eta() const { return eta_; }
+double MeasuredTauLepton::phi() const { return phi_; }
+double MeasuredTauLepton::mass() const { return preciseVisMass_; }
+
+double MeasuredTauLepton::energy() const { return energy_; }
+double MeasuredTauLepton::px() const { return px_; }
+double MeasuredTauLepton::py() const { return py_; }
+double MeasuredTauLepton::pz() const { return pz_; }
+
+double MeasuredTauLepton::p() const { return p_; }
+
+int MeasuredTauLepton::decayMode() const { return decayMode_; }
+
+LorentzVector MeasuredTauLepton::p4() const { return p4_; }
+
+Vector MeasuredTauLepton::p3() const { return p3_; }
+
+double MeasuredTauLepton::cosPhi_sinTheta() const { return cosPhi_sinTheta_; }
+double MeasuredTauLepton::sinPhi_sinTheta() const { return sinPhi_sinTheta_; }
+double MeasuredTauLepton::cosTheta() const { return cosTheta_; }
+
+void MeasuredTauLepton::roundToNdigits(unsigned int nDigis)
+{
+pt_ = classic_svFit::roundToNdigits(pt_, nDigis);
+eta_ = classic_svFit::roundToNdigits(eta_, nDigis);
+phi_ = classic_svFit::roundToNdigits(phi_, nDigis);
+mass_ = classic_svFit::roundToNdigits(mass_, nDigis);
+initialize();
+}
+
+void MeasuredTauLepton::initialize()
+{
+  // CV: relations between pT and p, energy taken from http://en.wikipedia.org/wiki/Pseudorapidity
+  p_  = pt_*TMath::CosH(eta_);
+  px_ = pt_*TMath::Cos(phi_);
+  py_ = pt_*TMath::Sin(phi_);
+  pz_ = pt_*TMath::SinH(eta_);
+  energy_ = TMath::Sqrt(p_*p_ + preciseVisMass_*preciseVisMass_);
+  p4_ = LorentzVector(px_, py_, pz_, energy_);
+  p3_ = Vector(px_, py_, pz_);
+  double theta = p4_.theta();
+  cosPhi_sinTheta_ = TMath::Cos(phi_)*TMath::Sin(theta);
+  sinPhi_sinTheta_ = TMath::Sin(phi_)*TMath::Sin(theta);
+  cosTheta_ = TMath::Cos(theta);
+}

--- a/python/helpers/FastMTT_cc/MeasuredTauLepton.h
+++ b/python/helpers/FastMTT_cc/MeasuredTauLepton.h
@@ -1,0 +1,109 @@
+#ifndef TauAnalysis_ClassicSVfit_MeasuredTauLepton_h
+#define TauAnalysis_ClassicSVfit_MeasuredTauLepton_h
+
+#include "svFitAuxFunctions.h"
+
+namespace classic_svFit
+{
+  class MeasuredTauLepton
+  {
+   public:
+    /**
+       \enum    MeasuredTauLepton::kDecayType
+       \brief   enumeration of all tau decay types
+    */
+    enum kDecayType {
+      kUndefinedDecayType,
+      kTauToHadDecay,  /* < hadronic tau lepton decay                                                        */
+      kTauToElecDecay, /* < tau lepton decay to electron                                                     */
+      kTauToMuDecay    /* < tau lepton decay to muon                                                         */
+    };
+
+    MeasuredTauLepton();
+    MeasuredTauLepton(int, double, double, double, double, int = -1);
+    MeasuredTauLepton(const MeasuredTauLepton&);
+    ~MeasuredTauLepton();
+
+    /// return decay type of the tau lepton
+    int type() const;
+
+    /// return pt of the measured tau lepton in labframe
+    double pt() const;
+    /// return pseudo-rapidity of the measured tau lepton in labframe
+    double eta() const;
+    /// return azimuthal angle of the measured tau lepton in labframe
+    double phi() const;
+    /// return visible mass in labframe
+    double mass() const;
+
+    /// return visible energy in labframe
+    double energy() const;
+    /// return px of the measured tau lepton in labframe
+    double px() const;
+    /// return py of the measured tau lepton in labframe
+    double py() const;
+    /// return pz of the measured tau lepton in labframe
+    double pz() const;
+
+    /// return the measured tau lepton momentum in labframe
+    double p() const;
+
+    /// return decay mode of the reconstructed hadronic tau decay
+    int decayMode() const;
+
+    /// return the lorentz vector in the labframe
+    LorentzVector p4() const;
+
+    /// return the momentum vector in the labframe
+    Vector p3() const;
+
+    /// return auxiliary data-members to speed-up numerical computations
+    double cosPhi_sinTheta() const;
+    double sinPhi_sinTheta() const;
+    double cosTheta() const;
+
+    void roundToNdigits(unsigned int nDigis = 3);
+
+   protected:
+    /// set visible momentum in all coordinates systems
+    void initialize();
+
+   private:
+    /// decay type
+    int type_;
+
+    /// visible momentum in labframe (in polar coordinates)
+    double pt_;
+    double eta_;
+    double phi_;
+    double mass_;
+
+    /// visible momentum in labframe (in cartesian coordinates)
+    double energy_;
+    double px_;
+    double py_;
+    double pz_;
+
+    /// visible momentum in labframe (magnitude);
+    double p_;
+
+    /// decay mode (hadronic tau decays only)
+    int decayMode_;
+
+    /// visible momentum in labframe (four-vector)
+    LorentzVector p4_;
+
+    /// visible momentum in labframe
+    Vector p3_;
+
+    /// mass of visible tau decay products (recomputed to reduce rounding errors)
+    double preciseVisMass_;
+
+    /// auxiliary data-members to speed-up numerical computations
+    double cosPhi_sinTheta_;
+    double sinPhi_sinTheta_;
+    double cosTheta_;
+  };
+}
+
+#endif

--- a/python/helpers/FastMTT_cc/svFitAuxFunctions.cc
+++ b/python/helpers/FastMTT_cc/svFitAuxFunctions.cc
@@ -1,0 +1,231 @@
+#include "svFitAuxFunctions.h"
+
+#include <TMath.h>
+#include <TF1.h>
+#include <TFitResult.h>
+
+namespace classic_svFit
+{
+
+double roundToNdigits(double x, int n)
+{
+  double tmp = TMath::Power(10., n);
+  if ( x != 0. ) {
+    tmp /= TMath::Power(10., TMath::Floor(TMath::Log10(TMath::Abs(x))));
+  }
+  double x_rounded = TMath::Nint(x*tmp)/tmp;
+  //std::cout << "<roundToNdigits>: x = " << x << ", x_rounded = " << x_rounded << std::endl;
+  return x_rounded;
+}
+
+TGraphErrors* makeGraph(const std::string& graphName, const std::vector<GraphPoint>& graphPoints)
+{
+  //std::cout << "<makeGraph>:" << std::endl;
+  size_t numPoints = graphPoints.size();
+  //std::cout << " numPoints = " << numPoints << std::endl;
+  TGraphErrors* graph = new TGraphErrors(numPoints);
+  graph->SetName(graphName.data());
+  for ( size_t iPoint = 0; iPoint < numPoints; ++iPoint ) {
+    const GraphPoint& graphPoint = graphPoints[iPoint];
+    graph->SetPoint(iPoint, graphPoint.x_, graphPoint.y_);
+    graph->SetPointError(iPoint, graphPoint.xErr_, graphPoint.yErr_);
+  }
+  return graph;
+}
+
+void extractResult(TGraphErrors* graph, double& mass, double& massErr, double& Lmax, int verbosity)
+{
+  // determine range of mTest values that are within ~2 sigma interval within maximum of likelihood function
+  double x_Lmax = 0.;
+  double y_Lmax = 0.;
+  double idxPoint_Lmax = -1;
+  for ( int iPoint = 0; iPoint < graph->GetN(); ++iPoint ) {
+    double x, y;
+    graph->GetPoint(iPoint, x, y);
+    if ( y > y_Lmax ) {
+      x_Lmax = x;
+      y_Lmax = y;
+      idxPoint_Lmax = iPoint;
+    }
+  }
+
+  double xMin = 1.e+6;
+  double xMax = 0.;
+  for ( int iPoint = 0; iPoint < graph->GetN(); ++iPoint ) {
+    double x, y;
+    graph->GetPoint(iPoint, x, y);
+    if ( x < xMin ) xMin = x;
+    if ( x > xMax ) xMax = x;
+  }
+
+  // fit log-likelihood function within ~2 sigma interval within maximum
+  // with parabola
+  std::vector<GraphPoint> graphPoints_forFit;
+  double xMin_fit = 1.e+6;
+  double xMax_fit = 0.;
+  for ( int iPoint = 0; iPoint < graph->GetN(); ++iPoint ) {
+    double x, y;
+    graph->GetPoint(iPoint, x, y);
+    double xErr = graph->GetErrorX(iPoint);
+    double yErr = graph->GetErrorY(iPoint);
+    //std::cout << "point #" << iPoint << ": x = " << x << " +/- " << xErr << ", y = " << y << " +/- " << yErr << std::endl;
+    if ( y > (1.e-1*y_Lmax) && TMath::Abs(iPoint - idxPoint_Lmax) <= 5 ) {
+      GraphPoint graphPoint;
+      graphPoint.x_ = x;
+      graphPoint.xErr_ = xErr;
+      if ( (x - xErr) < xMin_fit ) xMin_fit = x - xErr;
+      if ( (x + xErr) > xMax_fit ) xMax_fit = x + xErr;
+      graphPoint.y_ = -TMath::Log(y);
+      graphPoint.yErr_ = yErr/y;
+      graphPoints_forFit.push_back(graphPoint);
+    }
+  }
+
+  TGraphErrors* likelihoodGraph_forFit = makeGraph("svFitLikelihoodGraph_forFit", graphPoints_forFit);
+  int numPoints = likelihoodGraph_forFit->GetN();
+  bool useFit = false;
+  if ( numPoints >= 3 ) {
+    TF1* fitFunction = new TF1("fitFunction", "TMath::Power((x - [0])/[1], 2.) + [2]", xMin_fit, xMax_fit);
+    fitFunction->SetParameter(0, x_Lmax);
+    fitFunction->SetParameter(1, 0.20*x_Lmax);
+    fitFunction->SetParameter(2, -TMath::Log(y_Lmax));
+
+    std::string fitOptions = "NSQ";
+    //if ( !verbosity ) fitOptions.append("Q");
+    TFitResultPtr fitResult = likelihoodGraph_forFit->Fit(fitFunction, fitOptions.data());
+    if ( fitResult.Get() ) {
+      if ( verbosity >= 1 ) {
+        std::cout << "fitting graph of p versus M(test) in range " << xMin_fit << ".." << xMax_fit << ", result:" << std::endl;
+        std::cout << " parameter #0 = " << fitFunction->GetParameter(0) << " +/- " << fitFunction->GetParError(0) << std::endl;
+        std::cout << " parameter #1 = " << fitFunction->GetParameter(1) << " +/- " << fitFunction->GetParError(1) << std::endl;
+        std::cout << " parameter #2 = " << fitFunction->GetParameter(2) << " +/- " << fitFunction->GetParError(2) << std::endl;
+        std::cout << "chi^2 = " << fitResult->Chi2() << std::endl;
+      }
+      if ( fitResult->Chi2() < (10.*numPoints) &&
+           fitFunction->GetParameter(0) > xMin && fitFunction->GetParameter(0) < xMax &&
+           TMath::Abs(fitFunction->GetParameter(0) - x_Lmax) < (0.10*x_Lmax) ) {
+        mass = fitFunction->GetParameter(0);
+        massErr = TMath::Sqrt(square(fitFunction->GetParameter(1)) + square(fitFunction->GetParError(0)));
+        Lmax = TMath::Exp(-fitFunction->GetParameter(2));
+        //std::cout << "fit: mass = " << mass << " +/- " << massErr << " (Lmax = " << Lmax << ")" << std::endl;
+        useFit = true;
+      }
+    } else {
+      std::cerr << "Warning in <extractResult>: Fit did not converge !!" << std::endl;
+    }
+    delete fitFunction;
+  }
+  if ( !useFit ) {
+    mass = x_Lmax;
+    massErr = TMath::Sqrt(0.5*(square(x_Lmax - xMin_fit) + square(xMax_fit - x_Lmax)))/TMath::Sqrt(2.*TMath::Log(10.));
+    Lmax = y_Lmax;
+    //std::cout << "graph: mass = " << mass << " +/- " << massErr << " (Lmax = " << Lmax << ")" << std::endl;
+  }
+
+  delete likelihoodGraph_forFit;
+}
+
+Vector normalize(const Vector& p)
+{
+  double p_x = p.x();
+  double p_y = p.y();
+  double p_z = p.z();
+  double mag2 = square(p_x) + square(p_y) + square(p_z);
+  if ( mag2 <= 0. ) return p;
+  double mag = TMath::Sqrt(mag2);
+  return Vector(p_x/mag, p_y/mag, p_z/mag);
+}
+
+double compScalarProduct(const Vector& p1, const Vector& p2)
+{
+  return (p1.x()*p2.x() + p1.y()*p2.y() + p1.z()*p2.z());
+}
+
+Vector compCrossProduct(const Vector& p1, const Vector& p2)
+{
+  double p3_x = p1.y()*p2.z() - p1.z()*p2.y();
+  double p3_y = p1.z()*p2.x() - p1.x()*p2.z();
+  double p3_z = p1.x()*p2.y() - p1.y()*p2.x();
+  return Vector(p3_x, p3_y, p3_z);
+}
+
+double compCosThetaNuNu(double visEn, double visP, double visMass2, double nunuEn, double nunuP, double nunuMass2)
+{
+  double cosThetaNuNu = (visEn*nunuEn - 0.5*(tauLeptonMass2 - (visMass2 + nunuMass2)))/(visP*nunuP);
+  return cosThetaNuNu;
+}
+
+double compPSfactor_tauToLepDecay(double x, double visEn, double visP, double visMass, double nunuEn, double nunuP, double nunuMass)
+{
+  //std::cout << "<compPSfactor_tauToLepDecay>:" << std::endl;
+  //std::cout << " x = " << x << std::endl;
+  //std::cout << " visEn = " << visEn << std::endl;
+  //std::cout << " visP = " << visP << std::endl;
+  //std::cout << " visMass = " << visMass << std::endl;
+  //std::cout << " nunuEn = " << nunuEn << std::endl;
+  //std::cout << " nunuP = " << nunuP << std::endl;
+  //std::cout << " nunuMass = " << nunuMass << std::endl;
+  double visMass2 = square(visMass);
+  double nunuMass2 = square(nunuMass);
+  if ( x >= (visMass2/tauLeptonMass2) && x <= 1. && nunuMass2 < ((1. - x)*tauLeptonMass2) ) { // physical solution
+    double tauEn_rf = (tauLeptonMass2 + nunuMass2 - visMass2)/(2.*nunuMass);
+    double visEn_rf = tauEn_rf - nunuMass;
+    if ( !(tauEn_rf >= tauLeptonMass && visEn_rf >= visMass) ) return 0.;
+    double I = nunuMass2*(2.*tauEn_rf*visEn_rf - (2./3.)*TMath::Sqrt((square(tauEn_rf) - tauLeptonMass2)*(square(visEn_rf) - visMass2)));
+    #ifdef XSECTION_NORMALIZATION
+    I *= GFfactor;    
+    #endif
+    double cosThetaNuNu = compCosThetaNuNu(visEn, visP, visMass2, nunuEn, nunuP, nunuMass2);
+    if ( !(cosThetaNuNu >= (-1. + epsilon) && cosThetaNuNu <= +1.) ) return 0.;
+    double PSfactor = (visEn + nunuEn)*I/(8.*visP*square(x)*TMath::Sqrt(square(visP) + square(nunuP) + 2.*visP*nunuP*cosThetaNuNu + tauLeptonMass2));
+    //-------------------------------------------------------------------------
+    // CV: fudge factor to reproduce literature value for cross-section times branching fraction
+    #ifdef XSECTION_NORMALIZATION
+    PSfactor *= 2.;
+    #endif
+    //-------------------------------------------------------------------------
+    return PSfactor;
+  } else {
+    return 0.;
+  }
+}
+
+double compPSfactor_tauToHadDecay(double x, double visEn, double visP, double visMass, double nuEn, double nuP)
+{
+  //std::cout << "<compPSfactor_tauToHadDecay>:" << std::endl;
+  //std::cout << " x = " << x << std::endl;
+  //std::cout << " visEn = " << visEn << std::endl;
+  //std::cout << " visP = " << visP << std::endl;
+  //std::cout << " visMass = " << visMass << std::endl;
+  //std::cout << " nuEn = " << nuEn << std::endl;
+  //std::cout << " nuP = " << nuP << std::endl;
+  double visMass2 = square(visMass);
+  if ( x >= (visMass2/tauLeptonMass2) && x <= 1. ) { // physical solution
+    double cosThetaNu = compCosThetaNuNu(visEn, visP, visMass2, nuEn, nuP, 0.);
+    //std::cout << "cosThetaNu = " << cosThetaNu << std::endl;
+    if ( !(cosThetaNu >= (-1. + epsilon) && cosThetaNu <= +1.) ) return 0.;
+    double PSfactor = (visEn + nuEn)/(8.*visP*square(x)*TMath::Sqrt(square(visP) + square(nuP) + 2.*visP*nuP*cosThetaNu + tauLeptonMass2));
+    PSfactor *= 1.0/(tauLeptonMass2 - visMass2);
+    //-------------------------------------------------------------------------
+    // CV: multiply by constant matrix element,
+    //     chosen such that the branching fraction of the tau to decay into hadrons is reproduced
+    //const double M2 = 16.*TMath::Pi()*cube(tauLeptonMass)*GammaTauToHad/(tauLeptonMass2 - visMass2);
+    //Remove multiplication as it add to execution time, and does not alter the result.
+    #ifdef XSECTION_NORMALIZATION
+    PSfactor *= M2;
+    #endif
+    //-------------------------------------------------------------------------
+    return PSfactor;
+  } else {
+    return 0.;
+  }
+}
+
+void integrationParameters::reset(){
+      idx_X_ = -1;
+      idx_phi_ = -1;
+      idx_VisPtShift_ = -1;
+      idx_mNuNu_ = -1;
+}
+
+}

--- a/python/helpers/FastMTT_cc/svFitAuxFunctions.h
+++ b/python/helpers/FastMTT_cc/svFitAuxFunctions.h
@@ -1,0 +1,145 @@
+#ifndef TauAnalysis_ClassicSVfit_svFitAuxFunctions_h
+#define TauAnalysis_ClassicSVfit_svFitAuxFunctions_h
+
+#include <TGraphErrors.h>
+#include "Math/LorentzVector.h"
+#include "Math/Vector3D.h"
+
+#include <vector>
+#include <string>
+
+namespace classic_svFit
+{
+  inline double square(double x)
+  {
+    return x*x;
+  }
+
+  inline double cube(double x)
+  {
+    return x*x*x;
+  }
+
+  inline double fourth(double x)
+  {
+    return x*x*x*x;
+  }
+
+  inline double fifth(double x)
+  {
+    return x*x*x*x*x;
+  }
+
+  inline double sixth(double x)
+  {
+    return x*x*x*x*x*x;
+  }
+
+  inline double seventh(double x)
+  {
+    return x*x*x*x*x*x*x;
+  }
+
+  inline double eigth(double x)
+  {
+    return x*x*x*x*x*x*x*x;
+  }
+
+  const double epsilon = 1E-3;
+  //-----------------------------------------------------------------------------
+  // define masses, widths and lifetimes of particles
+  // relevant for computing values of likelihood functions in SVfit algorithm
+  //
+  // NOTE: the values are taken from
+  //        K. Nakamura et al. (Particle Data Group),
+  //        J. Phys. G 37, 075021 (2010)
+  //
+  const double electronMass = 0.51100e-3; // GeV
+  const double electronMass2 = electronMass*electronMass;
+  const double muonMass = 0.10566; // GeV
+  const double muonMass2 = muonMass*muonMass;
+
+  const double chargedPionMass = 0.13957; // GeV
+  const double chargedPionMass2 = chargedPionMass*chargedPionMass;
+  const double neutralPionMass = 0.13498; // GeV
+  const double neutralPionMass2 = neutralPionMass*neutralPionMass;
+
+  const double rhoMesonMass = 0.77526; // GeV
+  const double rhoMesonMass2 = rhoMesonMass*rhoMesonMass;
+  const double a1MesonMass = 1.230; // GeV
+  const double a1MesonMass2 = a1MesonMass*a1MesonMass;
+
+  const double tauLeptonMass = 1.77685; // GeV
+  const double tauLeptonMass2 = tauLeptonMass*tauLeptonMass;
+  const double tauLeptonMass3 = tauLeptonMass2*tauLeptonMass;
+  const double tauLeptonMass4 = tauLeptonMass3*tauLeptonMass;
+  const double cTauLifetime = 8.711e-3; // centimeters
+
+  const double hbar_c = 0.1973; // GeV fm
+  const double ctau = 87.e+9; // tau lifetime = 87 microns, converted to fm
+  const double GammaTau = hbar_c/ctau;
+  const double GammaTauToElec = GammaTau*0.178; // BR(tau -> e) = 17.8%
+  const double GammaTauToMu = GammaTau*0.174; // BR(tau -> mu) = 17.4%
+  const double GammaTauToHad = GammaTau*0.648; // BR(tau -> hadrons) = 64.8%
+
+  #ifdef XSECTION_NORMALIZATION
+  const double GF = 1.166e-5; // in units of GeV^-2
+  const double GFfactor = square(GF)/square(M_PI);
+  const double M2 = 16.*M_PI*cube(tauLeptonMass)*GammaTauToHad;
+  #endif
+
+  const double conversionFactor = 1.e+10*square(hbar_c); // conversion factor from GeV^-2 to picobarn = 10^-40m//FIX ME store this
+  const double constFactor = 2.*conversionFactor/eigth(2.*M_PI);
+  const double matrixElementNorm = square(M_PI/(tauLeptonMass*GammaTau));// CV: multiply matrix element by factor (Pi/(mTau GammaTau))^2 from Luca's write-up
+
+  //const double v2 = square(246.22); // GeV^2
+  //-----------------------------------------------------------------------------
+
+  /**
+     \typedef SVfitStandalone::Vector
+     \brief   spacial momentum vector (equivalent to reco::Candidate::Vector)
+  */
+  typedef ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> > Vector;
+  /**
+     \typedef SVfitStandalone::LorentzVector
+     \brief   lorentz vector (equivalent to reco::Candidate::LorentzVector)
+  */
+  typedef ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > LorentzVector;
+
+  double roundToNdigits(double, int = 3);
+
+  struct GraphPoint
+  {
+    double x_;
+    double xErr_;
+    double y_;
+    double yErr_;
+    double mTest_step_;
+  };
+  TGraphErrors* makeGraph(const std::string&, const std::vector<GraphPoint>&);
+
+  void extractResult(TGraphErrors*, double&, double&, double&, int = 0);
+
+  Vector normalize(const Vector&);
+  double compScalarProduct(const Vector&, const Vector&);
+  Vector compCrossProduct(const Vector&, const Vector&);
+
+  double compCosThetaNuNu(double, double, double, double, double, double);
+  double compPSfactor_tauToLepDecay(double, double, double, double, double, double, double);
+  double compPSfactor_tauToHadDecay(double, double, double, double, double, double);
+
+  const int maxNumberOfDimensions = 6;
+  const int numberOfLegs = 2;
+
+struct integrationParameters{
+
+    int idx_X_ = -1;
+    int idx_phi_ = -1;
+    int idx_VisPtShift_ = -1;
+    int idx_mNuNu_ = -1;
+
+    void reset();
+};
+
+}
+#endif

--- a/python/helpers/higgsPairingAlgorithm_v2.py
+++ b/python/helpers/higgsPairingAlgorithm_v2.py
@@ -1,0 +1,302 @@
+import ROOT
+import math
+import itertools
+from PhysicsTools.NanoNN.helpers.utils import polarP4, deltaR
+
+def manualPermutation(input1, input2, input3=[0]):
+  output = []
+  for i1,v1 in enumerate(input1):
+    for i2,v2 in enumerate(input2):
+      if v1==v2 or (input1==input2 and i2<=i1): continue
+      if v1.startswith("JP") and v2.startswith("JP") and len(list(set(v1.split("_")[1:]+v2.split("_")[1:])))<4: continue
+      if v1.startswith("TauP") and v2.startswith("TauP") and len(list(set(v1.split("_")[1:]+v2.split("_")[1:])))<4: continue
+      for i3,v3 in enumerate(input3):
+        if v3!=0:
+          if v1==v3 or (input1==input3 and i3<=i1): continue
+          if v2==v3 or (input2==input3 and i3<=i2): continue
+          if v1.startswith("JP") and v3.startswith("JP") and len(list(set(v1.split("_")[1:]+v3.split("_")[1:])))<4: continue
+          if v1.startswith("TauP") and v3.startswith("TauP") and len(list(set(v1.split("_")[1:]+v3.split("_")[1:])))<4: continue
+          if v2.startswith("JP") and v3.startswith("JP") and len(list(set(v2.split("_")[1:]+v3.split("_")[1:])))<4: continue
+          if v2.startswith("TauP") and v3.startswith("TauP") and len(list(set(v2.split("_")[1:]+v3.split("_")[1:])))<4: continue
+          output.append([v1,v2,v3])
+        else:
+          output.append([v1,v2])
+  return output
+
+def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, dotaus=False, taus=[], XtautauWP=0.0, METvars=[]):
+
+    # save jets properties
+    dummyJet = polarP4()
+    dummyJet.HiggsMatch = False
+    dummyJet.HiggsMatchIndex = -1
+    dummyJet.FatJetMatch = False
+    dummyJet.btagDeepFlavB = -1
+    dummyJet.btagPNetB = -1
+    dummyJet.DM = -1
+    dummyJet.kind = -1
+    dummyJet.DeepTauVsJet = -1
+    dummyJet.hadronFlavour = -1
+    dummyJet.jetId = -1
+    dummyJet.puId = -1
+    dummyJet.rawFactor = -1
+    dummyJet.bRegCorr = -1
+    dummyJet.bRegRes = -1
+    dummyJet.cRegCorr = -1
+    dummyJet.cRegRes = -1
+    dummyJet.MatchedGenPt = 0
+    dummyJet.mass = 0.
+
+    dummyHiggs = polarP4()
+    dummyHiggs.matchH1 = False
+    dummyHiggs.matchH2 = False
+    dummyHiggs.matchH3 = False
+    dummyHiggs.mass = 0.
+    dummyHiggs.Mass = 0.
+    dummyHiggs.pt = -1
+    dummyHiggs.eta = -1
+    dummyHiggs.phi = -1
+    dummyHiggs.dRjets = 0.
+
+    probetau = sorted([fj for fj in fatjets if fj.Xtautau > XtautauWP], key=lambda x: x.Xtautau, reverse = True)
+    if len(probetau)>0:
+        probetau = probetau[0]
+    probejets = sorted([fj for fj in fatjets if fj.Xbb > XbbWP and fj!=probetau], key=lambda x: x.Xbb, reverse = True)
+    if len(probejets) > 4:
+        probejets = probejets[:4]
+    if probetau!=[]:
+        if dotaus:
+            if len(probejets) <= 3:
+                probejets.append(probetau)
+            else:
+                probejets = probejets[:3]+[probetau]
+        elif probetau.Xbb > XbbWP:
+            if len(probejets) <= 3:
+                probejets.append(probetau)
+            elif probetau.Xbb > probejets[3].Xbb:
+                probejets[3] = probetau
+        if not dotaus: probetau = []
+
+    if dotaus:
+        # Prepare MET variables for FastMTT
+        MET_x = METvars[0]*math.cos(METvars[1])
+        MET_y = METvars[0]*math.sin(METvars[1])
+        covMET = ROOT.TMatrixD(2,2)
+        covMET[0][0] = METvars[2]
+        covMET[1][0] = METvars[3]
+        covMET[0][1] = METvars[3]
+        covMET[1][1] = METvars[4]
+
+
+    jets_4vec = []
+    for j in jets:
+        overlap = False
+        for fj in probejets:
+            if deltaR(j,fj) < 0.8: overlap = True
+        if overlap == False:
+            j_tmp = polarP4(j)
+            j_tmp.HiggsMatch = j.HiggsMatch
+            j_tmp.HiggsMatchIndex = j.HiggsMatchIndex
+            j_tmp.FatJetMatch = j.FatJetMatch
+            j_tmp.btagDeepFlavB = j.btagDeepFlavB
+            j_tmp.btagPNetB = j.btagPNetB
+            j_tmp.DM = -1
+            j_tmp.kind = -1
+            j_tmp.DeepTauVsJet = -1
+            if isMC:
+                j_tmp.hadronFlavour = j.hadronFlavour
+            j_tmp.jetId = j.jetId
+            j_tmp.rawFactor = j.rawFactor
+            j_tmp.mass = j.mass
+            j_tmp.MatchedGenPt = j.MatchedGenPt
+            if Run==2:
+                j_tmp.puId = j.puId
+                j_tmp.bRegCorr = j.bRegCorr
+                j_tmp.bRegRes = j.bRegRes
+                j_tmp.cRegCorr = j.cRegCorr
+                j_tmp.cRegRes = j.cRegRes
+
+            jets_4vec.append(j_tmp)
+
+    if len(jets_4vec) > 10:
+        jets_4vec = jets_4vec[:10]
+
+    jetpairs = []
+    for i1,j1 in enumerate(jets_4vec):
+      for i2,j2 in enumerate(jets_4vec):
+        if i2<=i1: continue
+        jetpairs.append((i1,i2,(j1+j2),j1.btagPNetB*j2.btagPNetB,"Jet",(j1+j2).M()))
+    jetpairs = sorted([p for p in jetpairs], key=lambda x: x[3], reverse = True)
+
+    taus_4vec = []
+    for t in taus:
+        overlap = False
+        for fj in probejets:
+            if deltaR(t,fj) < 0.8: overlap = True
+        if overlap == False:
+            t_tmp = polarP4(t)
+            t_tmp.HiggsMatch = t.HiggsMatch
+            t_tmp.HiggsMatchIndex = t.HiggsMatchIndex
+            t_tmp.FatJetMatch = t.FatJetMatch
+            t_tmp.charge = t.charge
+            t_tmp.btagDeepFlavB = -1
+            t_tmp.btagPNetB = -1
+            t_tmp.kind = t.kind
+            t_tmp.DM = t.decayMode
+            if Run==2:
+                t_tmp.DeepTauVsJet = t.rawDeepTau2017v2p1VSjet
+            else:
+                t_tmp.DeepTauVsJet = t.rawDeepTau2018v2p5VSjet
+            if isMC:
+                t_tmp.hadronFlavour = -1
+            t_tmp.jetId = -1
+            t_tmp.rawFactor = -1
+            t_tmp.mass = t.mass
+            t_tmp.MatchedGenPt = t.MatchedGenPt
+            if Run==2:
+                t_tmp.puId = -1
+                t_tmp.bRegCorr = -1
+                t_tmp.bRegRes = -1
+                t_tmp.cRegCorr = -1
+                t_tmp.cRegRes = -1
+
+            taus_4vec.append(t_tmp)
+
+    if len(taus_4vec) > 4:
+        taus_4vec = taus_4vec[:4]
+
+    taupairs = []
+    for i1,t1 in enumerate(taus_4vec):
+      for i2,t2 in enumerate(taus_4vec):
+        if i2<=i1: continue
+        if t1.charge * t2.charge >= 0: continue
+        tau1 = ROOT.MeasuredTauLepton(t1.kind, t1.Pt(), t1.Eta(), t1.Phi(), t1.mass, t1.DM)
+        tau2 = ROOT.MeasuredTauLepton(t2.kind, t2.Pt(), t2.Eta(), t2.Phi(), t2.mass, t2.DM)
+        VectorOfTaus = ROOT.std.vector('MeasuredTauLepton')
+        bothtaus = VectorOfTaus()
+        bothtaus.push_back(tau1)
+        bothtaus.push_back(tau2)
+        FMTT = ROOT.FastMTT()
+        FMTT.run(bothtaus, MET_x, MET_y, covMET)
+        FMTToutput = FMTT.getBestP4()
+        FastMTTmass = FMTToutput.M()
+        taupairs.append((i1,i2,(t1+t2),t1.DeepTauVsJet*t2.DeepTauVsJet,"Tau",FastMTTmass))
+    taupairs = sorted([p for p in taupairs], key=lambda x: x[3], reverse = True)
+
+    allobjects = {}
+    for i,fj in enumerate(probejets):
+      if fj!=probetau: allobjects["FJ"+str(i+1)] = fj
+    if probetau!=[]: allobjects["FatTau"] = probetau
+    for i,j in enumerate(jetpairs):
+      allobjects["JP_"+str(j[0]+1)+"_"+str(j[1]+1)] = j
+    for i,t in enumerate(taupairs):
+      allobjects["TauP_"+str(t[0]+1)+"_"+str(t[1]+1)] = t
+    objlist_jet = [k for k in allobjects if "J" in k]
+    objlist_tau = [k for k in allobjects if "Tau" in k]
+
+    if dotaus:
+      # Try to make 3H: 2b+1t
+      permutations = manualPermutation(objlist_jet, objlist_jet, objlist_tau)
+      if permutations==[]:
+        # Either 2b only or 1b+1t
+        permnotau = manualPermutation(objlist_jet, objlist_jet)
+        permoneb = manualPermutation(objlist_jet, objlist_tau)
+        assert permnotau==[] or permoneb==[]
+        permutations = permnotau+permoneb
+      if permutations==[]:
+        # Either 1b only or 1t only
+        #assert (objlist_jet==[] or objlist_tau==[]) and len(objlist_jet+objlist_tau)<=3, "Shouldn't this be just one pair? ["+", ".join(objlist_jet)+"] and ["+", ".join(objlist_tau)+"]" # We CAN have multiple Tau pairs! Previous steps fail because there's not a single jet pair
+        assert (objlist_jet==[] or objlist_tau==[]) and len(objlist_jet)<=3
+        if len(objlist_jet+objlist_tau)>=1:
+          permutations = [[obj] for obj in objlist_jet+objlist_tau]
+    else:
+      # Try 3b
+      permutations = manualPermutation(objlist_jet, objlist_jet, objlist_jet)
+      if permutations==[]:
+        # Try 2b
+        permutations = manualPermutation(objlist_jet, objlist_jet)
+      if permutations==[]:
+        # Either 1b or 0b
+        # "Worst case" can still have 3 jets, so 3 jet pairs. Since list is b-score-sorted, will just choose the one with highest score
+        assert len(objlist_jet)<=3
+        if len(objlist_jet)>=1:
+          permutations = [[obj] for obj in objlist_jet]
+
+    h = []
+    for i in range(3):
+      h.append(dummyHiggs)
+    j = []
+    for i in range(6):
+      j.append(dummyJet)
+    TauIsBoosted = 0
+    TauIsResolved = 0
+    if permutations==[]: return 0,0,h[0],h[1],h[2],j[0],j[1],j[2],j[3],j[4],j[5],TauIsBoosted,TauIsResolved
+    nHiggs = len(permutations[0])
+    assert all([nHiggs==len(perm) for perm in permutations])
+    assert all([len([name for name in perm if "Tau" in name])<=1 for perm in permutations])
+
+    min_chi2 = 1000000000000000
+    for permutation in permutations:
+      masses = []
+      for name in permutation:
+        thismass = allobjects[name].mass if name.startswith("F") else allobjects[name][5]
+        masses.append(thismass)
+      fitted_mass = sum(masses)/nHiggs
+      chi2 = 0.0
+      for m in masses:
+        chi2 += (m - fitted_mass)**2
+      if chi2 < min_chi2:
+        m_fit = fitted_mass
+        min_chi2 = chi2
+        finalPermutation = permutation
+      if nHiggs==1: break # Use the jet pair with highest score, which will be always the first
+
+    nBoostedH = len([name for name in finalPermutation if name.startswith("F")])
+    jetCandCount = 0
+    for i in range(nHiggs):
+      if finalPermutation[i].startswith("F"):
+        h[i] = allobjects[finalPermutation[i]]
+        setattr(h[i], "matchH"+str(i+1), h[i].HiggsMatch)
+        if Run==2:
+          h[i].Mass = h[i].particleNet_mass
+        else:
+          h[i].Mass = h[i].mass*h[i].particleNet_massCorr
+        h[i].dRjets = -1
+        if "Tau" in finalPermutation[i]: TauIsBoosted = i+1
+      else:
+        h[i] = allobjects[finalPermutation[i]][2]
+        h[i].Mass = allobjects[finalPermutation[i]][5] # h[i].M()
+        h[i].pt = h[i].Pt()
+        h[i].eta = h[i].Eta()
+        h[i].phi = h[i].Phi()
+        setattr(h[i], "matchH"+str(i+1), False)
+        if allobjects[finalPermutation[i]][4]=="Jet":
+          j[jetCandCount] = jets_4vec[allobjects[finalPermutation[i]][0]]
+          j[jetCandCount+1] = jets_4vec[allobjects[finalPermutation[i]][1]]
+          h[i].dRjets = deltaR(j[jetCandCount].eta(),j[jetCandCount].phi(),j[jetCandCount+1].eta(),j[jetCandCount+1].phi())
+          if j[jetCandCount].HiggsMatch == True and j[jetCandCount+1].HiggsMatch == True and j[jetCandCount].HiggsMatchIndex == j[jetCandCount+1].HiggsMatchIndex:
+            setattr(h[i], "matchH"+str(i+1), True)
+        elif allobjects[finalPermutation[i]][4]=="Tau":
+          j[jetCandCount] = taus_4vec[allobjects[finalPermutation[i]][0]]
+          j[jetCandCount+1] = taus_4vec[allobjects[finalPermutation[i]][1]]
+          h[i].dRjets = deltaR(j[jetCandCount].eta(),j[jetCandCount].phi(),j[jetCandCount+1].eta(),j[jetCandCount+1].phi())
+          if j[jetCandCount].HiggsMatch == True and j[jetCandCount+1].HiggsMatch == True and j[jetCandCount].HiggsMatchIndex == j[jetCandCount+1].HiggsMatchIndex:
+            setattr(h[i], "matchH"+str(i+1), True)
+        jetCandCount += 2
+        if "Tau" in finalPermutation[i]: TauIsResolved = i+1
+    if nHiggs==3:
+      #if nBoostedH==3: recoidx = 1
+      #elif nBoostedH==2: recoidx = 2
+      #elif nBoostedH==1: recoidx = 3
+      #elif nBoostedH==0: recoidx = 4
+      recoidx = 4-nBoostedH
+    elif nHiggs==2:
+      #if nBoostedH==2: recoidx = 5
+      #elif nBoostedH==1: recoidx = 6
+      #elif nBoostedH==0: recoidx = 7
+      recoidx = 7-nBoostedH
+    elif nHiggs==1:
+      #if nBoostedH==1: recoidx = 8
+      #elif nBoostedH==0: recoidx = 9
+      recoidx = 9-nBoostedH
+    # return reco_idx, fitted_mass, Higgs 1/2/3, Jets 1/2/3/4/5/6, TauBoosted H Idx, TauResolved H Idx
+    return recoidx,m_fit,h[0],h[1],h[2],j[0],j[1],j[2],j[3],j[4],j[5],TauIsBoosted,TauIsResolved

--- a/python/producers/hhh6bProducerPNetAK4.py
+++ b/python/producers/hhh6bProducerPNetAK4.py
@@ -279,14 +279,6 @@ class hhh6bProducerPNetAK4(Module):
         else:
             self._jmeLabels = []
 
-        # for bdt
-        #self._sfbdt_files = [
-        #    os.path.expandvars(
-        #        '$CMSSW_BASE/src/PhysicsTools/NanoHRTTools/data/sfBDT/ak15/xgb_train_qcd.model.%d' % idx)
-        #    for idx in range(10)]
-        #self._sfbdt_vars = ['fj_2_tau21', 'fj_2_sj1_rawmass', 'fj_2_sj2_rawmass',
-        #                    'fj_2_ntracks_sv12', 'fj_2_sj1_sv1_pt', 'fj_2_sj2_sv1_pt']
-
         # selection
         if self._opts['option']=="5": print('Select Events with FatJet1 pT > 200 GeV and PNetXbb > 0.8 only')
         elif self._opts['option']=="10": print('Select FatJets with pT > 200 GeV and tau3/tau2 < 0.54 only')
@@ -308,9 +300,6 @@ class hhh6bProducerPNetAK4(Module):
 
             for key,corr in self.fatjetCorrectors.items():
                 self.fatjetCorrectors[key].beginJob()
-
-        # for bdt
-        # self.xgb = XGBEnsemble(self._sfbdt_files, self._sfbdt_vars)
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.isMC = bool(inputTree.GetBranch('genWeight'))
@@ -353,7 +342,6 @@ class hhh6bProducerPNetAK4(Module):
         self.out.branch("nprobejets","I")
         self.out.branch("nHiggsMatchedJets","I")
 
-        #for idx in ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]):
         for idx in ([1, 2, 3]):
 
             prefix = 'fatJet%i' % idx
@@ -366,17 +354,10 @@ class hhh6bProducerPNetAK4(Module):
             self.out.branch(prefix + "MassSD", "F")
             self.out.branch(prefix + "MassSD_noJMS", "F")
             self.out.branch(prefix + "MassSD_UnCorrected", "F")
-            self.out.branch(prefix + "MassRegressed", "F")
-            self.out.branch(prefix + "MassRegressed_UnCorrected", "F")
             self.out.branch(prefix + "PNetXbb", "F")
             self.out.branch(prefix + "PNetXjj", "F")
             self.out.branch(prefix + "PNetQCD", "F")
             self.out.branch(prefix + "Area", "F")
-            #self.out.branch(prefix + "PNetQCDb", "F")
-            #self.out.branch(prefix + "PNetQCDbb", "F")
-            #self.out.branch(prefix + "PNetQCDc", "F")
-            #self.out.branch(prefix + "PNetQCDcc", "F")
-            #self.out.branch(prefix + "PNetQCDothers", "F")
             self.out.branch(prefix + "Tau3OverTau2", "F")
             self.out.branch(prefix + "GenMatchIndex", "I")
             self.out.branch(prefix + "HiggsMatchedIndex", "I")
@@ -391,7 +372,6 @@ class hhh6bProducerPNetAK4(Module):
 
             # here we form the MHH system w. mass regressed
             self.out.branch(prefix + "PtOverMHH", "F")
-            self.out.branch(prefix + "PtOverMHH_MassRegressed", "F")
             self.out.branch(prefix + "PtOverMSD", "F")
             self.out.branch(prefix + "PtOverMRegressed", "F")
 
@@ -401,20 +381,11 @@ class hhh6bProducerPNetAK4(Module):
                 self.out.branch(prefix + "MassSD_JMS_Up", "F")
                 self.out.branch(prefix + "MassSD_JMR_Down", "F")
                 self.out.branch(prefix + "MassSD_JMR_Up", "F")
-                self.out.branch(prefix + "MassRegressed_JMS_Down", "F")
-                self.out.branch(prefix + "MassRegressed_JMS_Up", "F")
-                self.out.branch(prefix + "MassRegressed_JMR_Down", "F")
-                self.out.branch(prefix + "MassRegressed_JMR_Up", "F")
 
                 self.out.branch(prefix + "PtOverMHH_JMS_Down", "F")
                 self.out.branch(prefix + "PtOverMHH_JMS_Up", "F")
                 self.out.branch(prefix + "PtOverMHH_JMR_Down", "F")
                 self.out.branch(prefix + "PtOverMHH_JMR_Up", "F")
-
-                self.out.branch(prefix + "PtOverMHH_MassRegressed_JMS_Down", "F")
-                self.out.branch(prefix + "PtOverMHH_MassRegressed_JMS_Up", "F")
-                self.out.branch(prefix + "PtOverMHH_MassRegressed_JMR_Down", "F")
-                self.out.branch(prefix + "PtOverMHH_MassRegressed_JMR_Up", "F")
 
                 if self._allJME:
                     for syst in self._jmeLabels:
@@ -422,142 +393,7 @@ class hhh6bProducerPNetAK4(Module):
                         self.out.branch(prefix + "Pt" + "_" + syst, "F")
                         self.out.branch(prefix + "PtOverMHH" + "_" + syst, "F")
 
-        # dihiggs variables
-        self.out.branch("hh_pt", "F")
-        self.out.branch("hh_eta", "F")
-        self.out.branch("hh_phi", "F")
-        self.out.branch("hh_mass", "F")
-
-        self.out.branch("hh_pt_MassRegressed", "F")
-        self.out.branch("hh_eta_MassRegressed", "F")
-        self.out.branch("hh_phi_MassRegressed", "F")
-        self.out.branch("hh_mass_MassRegressed", "F")
-
-        if self.isMC:
-            self.out.branch("hh_pt_JMR_Down", "F")
-            self.out.branch("hh_pt_JMR_Up", "F")
-            self.out.branch("hh_eta_JMR_Down", "F")
-            self.out.branch("hh_eta_JMR_Up", "F")
-            self.out.branch("hh_mass_JMR_Down", "F")
-            self.out.branch("hh_mass_JMR_Up", "F")
-
-            self.out.branch("hh_pt_JMS_Down", "F")
-            self.out.branch("hh_pt_JMS_Up", "F")
-            self.out.branch("hh_eta_JMS_Down", "F")
-            self.out.branch("hh_eta_JMS_Up", "F")
-            self.out.branch("hh_mass_JMS_Down", "F")
-            self.out.branch("hh_mass_JMS_Up", "F")
-
-            self.out.branch("hh_pt_MassRegressed_JMR_Down", "F")
-            self.out.branch("hh_pt_MassRegressed_JMR_Up", "F")
-            self.out.branch("hh_eta_MassRegressed_JMR_Down", "F")
-            self.out.branch("hh_eta_MassRegressed_JMR_Up", "F")
-            self.out.branch("hh_mass_MassRegressed_JMR_Down", "F")
-            self.out.branch("hh_mass_MassRegressed_JMR_Up", "F")
-
-            self.out.branch("hh_pt_MassRegressed_JMS_Down", "F")
-            self.out.branch("hh_pt_MassRegressed_JMS_Up", "F")
-            self.out.branch("hh_eta_MassRegressed_JMS_Down", "F")
-            self.out.branch("hh_eta_MassRegressed_JMS_Up", "F")
-            self.out.branch("hh_mass_MassRegressed_JMS_Down", "F")
-            self.out.branch("hh_mass_MassRegressed_JMS_Up", "F")
-
-        if self.isMC and self._allJME:
-            for syst in self._jmeLabels:
-                if syst == 'nominal': continue
-                self.out.branch("hh_pt" + "_" +syst, "F")
-                self.out.branch("hh_eta" + "_" +syst, "F")
-                self.out.branch("hh_mass" + "_" + syst, "F")
-                self.out.branch("hh_mass_MassRegressed" + "_" + syst, "F")
-
-        self.out.branch("deltaEta_j1j2", "F")
-        self.out.branch("deltaPhi_j1j2", "F")
-        self.out.branch("deltaR_j1j2", "F")
-        self.out.branch("ptj2_over_ptj1", "F")
-
-        self.out.branch("mj2_over_mj1", "F")
-        self.out.branch("mj2_over_mj1_MassRegressed", "F")
-
-        # tri-higgs variables
-        self.out.branch("hhh_pt", "F")
-        self.out.branch("hhh_eta", "F")
-        self.out.branch("hhh_phi", "F")
-        self.out.branch("hhh_mass", "F")
-
-        self.out.branch("hhh_pt_MassRegressed", "F")
-        self.out.branch("hhh_eta_MassRegressed", "F")
-        self.out.branch("hhh_phi_MassRegressed", "F")
-        self.out.branch("hhh_mass_MassRegressed", "F")
-
-        if self.isMC:
-            self.out.branch("hhh_pt_JMR_Down", "F")
-            self.out.branch("hhh_pt_JMR_Up", "F")
-            self.out.branch("hhh_eta_JMR_Down", "F")
-            self.out.branch("hhh_eta_JMR_Up", "F")
-            self.out.branch("hhh_mass_JMR_Down", "F")
-            self.out.branch("hhh_mass_JMR_Up", "F")
-
-            self.out.branch("hhh_pt_JMS_Down", "F")
-            self.out.branch("hhh_pt_JMS_Up", "F")
-            self.out.branch("hhh_eta_JMS_Down", "F")
-            self.out.branch("hhh_eta_JMS_Up", "F")
-            self.out.branch("hhh_mass_JMS_Down", "F")
-            self.out.branch("hhh_mass_JMS_Up", "F")
-
-            self.out.branch("hhh_pt_MassRegressed_JMR_Down", "F")
-            self.out.branch("hhh_pt_MassRegressed_JMR_Up", "F")
-            self.out.branch("hhh_eta_MassRegressed_JMR_Down", "F")
-            self.out.branch("hhh_eta_MassRegressed_JMR_Up", "F")
-            self.out.branch("hhh_mass_MassRegressed_JMR_Down", "F")
-            self.out.branch("hhh_mass_MassRegressed_JMR_Up", "F")
-
-            self.out.branch("hhh_pt_MassRegressed_JMS_Down", "F")
-            self.out.branch("hhh_pt_MassRegressed_JMS_Up", "F")
-            self.out.branch("hhh_eta_MassRegressed_JMS_Down", "F")
-            self.out.branch("hhh_eta_MassRegressed_JMS_Up", "F")
-            self.out.branch("hhh_mass_MassRegressed_JMS_Down", "F")
-            self.out.branch("hhh_mass_MassRegressed_JMS_Up", "F")
-
         # tri-higgs resolved variables
-        self.out.branch("h1_pt", "F")
-        self.out.branch("h1_eta", "F")
-        self.out.branch("h1_phi", "F")
-        self.out.branch("h1_mass", "F")
-        self.out.branch("h1_match", "O")
-
-        self.out.branch("h2_pt", "F")
-        self.out.branch("h2_eta", "F")
-        self.out.branch("h2_phi", "F")
-        self.out.branch("h2_mass", "F")
-        self.out.branch("h2_match", "O")
-
-        self.out.branch("h3_pt", "F")
-        self.out.branch("h3_eta", "F")
-        self.out.branch("h3_phi", "F")
-        self.out.branch("h3_mass", "F")
-        self.out.branch("h3_match", "O")
-
-        self.out.branch("h1_t2_pt", "F")
-        self.out.branch("h1_t2_eta", "F")
-        self.out.branch("h1_t2_phi", "F")
-        self.out.branch("h1_t2_mass", "F")
-        self.out.branch("h1_t2_match", "O")
-        self.out.branch("h1_t2_dRjets", "F")
-
-        self.out.branch("h2_t2_pt", "F")
-        self.out.branch("h2_t2_eta", "F")
-        self.out.branch("h2_t2_phi", "F")
-        self.out.branch("h2_t2_mass", "F")
-        self.out.branch("h2_t2_match", "O")
-        self.out.branch("h2_t2_dRjets", "F")
-
-        self.out.branch("h3_t2_pt", "F")
-        self.out.branch("h3_t2_eta", "F")
-        self.out.branch("h3_t2_phi", "F")
-        self.out.branch("h3_t2_mass", "F")
-        self.out.branch("h3_t2_match", "O")
-        self.out.branch("h3_t2_dRjets", "F")
-
         self.out.branch("h1_t3_pt", "F")
         self.out.branch("h1_t3_eta", "F")
         self.out.branch("h1_t3_phi", "F")
@@ -580,76 +416,16 @@ class hhh6bProducerPNetAK4(Module):
         self.out.branch("h3_t3_dRjets", "F")
 
         self.out.branch("h_fit_mass", "F")
-        self.out.branch("bdt", "F")
 
         # max min
-        self.out.branch("max_bcand_eta", "F")
-        self.out.branch("min_bcand_eta", "F")
         self.out.branch("max_h_eta", "F")
         self.out.branch("min_h_eta", "F")
 
         self.out.branch("max_h_dRjets", "F")
         self.out.branch("min_h_dRjets", "F")
 
-        self.out.branch("hhh_resolved_mass", "F")
-        self.out.branch("hhh_resolved_pt", "F")
-
-        # Dalitz variables
-        self.out.branch("h1h2_mass_squared", "F")
-        self.out.branch("h2h3_mass_squared", "F")
-
         self.out.branch("ngenvistau", "I")
         #self.out.branch("nsignaltaus","I") # This is the same as "ntaus"
-
-
-        if self.isMC and self._allJME:
-            for syst in self._jmeLabels:
-                if syst == 'nominal': continue
-                self.out.branch("hhh_pt" + "_" +syst, "F")
-                self.out.branch("hhh_eta" + "_" +syst, "F")
-                self.out.branch("hhh_mass" + "_" + syst, "F")
-                self.out.branch("hhh_mass_MassRegressed" + "_" + syst, "F")
-
-        self.out.branch("deltaEta_j1j3", "F")
-        self.out.branch("deltaPhi_j1j3", "F")
-        self.out.branch("deltaR_j1j3", "F")
-        self.out.branch("ptj3_over_ptj1", "F")
-
-        self.out.branch("mj3_over_mj1", "F")
-        self.out.branch("mj3_over_mj1_MassRegressed", "F")
-
-        self.out.branch("deltaEta_j2j3", "F")
-        self.out.branch("deltaPhi_j2j3", "F")
-        self.out.branch("deltaR_j2j3", "F")
-        self.out.branch("ptj3_over_ptj2", "F")
-
-        self.out.branch("mj3_over_mj2", "F")
-        self.out.branch("mj3_over_mj2_MassRegressed", "F")
-
-        # resolved tag: nBTaggedJets == 4
-
-        # for phase-space overlap removal with VBFHH->4b boosted analysis
-        # small jets
-        self.out.branch("isVBFtag", "I")
-        if self._allJME:
-            for syst in self._jmeLabels:
-                if syst == 'nominal': continue
-                self.out.branch("isVBFtag" + "_" + syst, "F")
-
-        self.out.branch("dijetmass", "F")
-
-        for idx in ([1, 2]):
-            prefix = 'vbfjet%i'%idx
-            self.out.branch(prefix + "Pt", "F")
-            self.out.branch(prefix + "Eta", "F")
-            self.out.branch(prefix + "Phi", "F")
-            self.out.branch(prefix + "Mass", "F")
-            
-            prefix = 'vbffatJet%i'%idx
-            self.out.branch(prefix + "Pt", "F")
-            self.out.branch(prefix + "Eta", "F")
-            self.out.branch(prefix + "Phi", "F")
-            self.out.branch(prefix + "PNetXbb", "F")
             
         # more small jets
         self.out.branch("nsmalljets", "I")
@@ -684,32 +460,6 @@ class hhh6bProducerPNetAK4(Module):
                 self.out.branch(prefix + "FatJetMatched", "O")
                 self.out.branch(prefix + "FatJetMatchedIndex", "I")
 
-        for idx in ([1, 2, 3, 4, 5, 6]):
-            prefix = 'bcand%i'%idx
-            self.out.branch(prefix + "Pt", "F")
-            self.out.branch(prefix + "Eta", "F")
-            self.out.branch(prefix + "Phi", "F")
-            self.out.branch(prefix + "DeepFlavB", "F")
-            self.out.branch(prefix + "PNetB", "F")
-            self.out.branch(prefix + "JetId", "F")
-            self.out.branch(prefix + "Mass", "F")
-            self.out.branch(prefix + "RawFactor", "F")
-            self.out.branch(prefix + "MatchedGenPt", "F")
-            if self.Run==2:
-                self.out.branch(prefix + "PuId", "F")
-                self.out.branch(prefix + "bRegCorr", "F")
-                self.out.branch(prefix + "bRegRes", "F")
-                self.out.branch(prefix + "cRegCorr", "F")
-                self.out.branch(prefix + "cRegRes", "F")
-
-
-            if self.isMC:
-                self.out.branch(prefix + "HadronFlavour", "F")
-                self.out.branch(prefix + "HiggsMatched", "O")
-                self.out.branch(prefix + "HiggsMatchedIndex", "I")
-
-
-
         # leptons
         for idx in ([1, 2]):
             prefix = 'lep%i'%idx
@@ -743,15 +493,6 @@ class hhh6bProducerPNetAK4(Module):
             self.out.branch(prefix + "Eta", "F")
             self.out.branch(prefix + "Phi", "F")
 
-        # TMVA booking
-        self.reader = ROOT.TMVA.Reader("!V:Color:Silent")
-        #for var in ['h_fit_mass', 'h1_t3_mass', 'h2_t3_mass', 'h3_t3_mass', 'h1_t3_dRjets', 'h2_t3_dRjets', 'h3_t3_dRjets', 'bcand1Pt', 'bcand2Pt', 'bcand3Pt', 'bcand4Pt','bcand5Pt', 'bcand6Pt', 'bcand1Eta', 'bcand2Eta', 'bcand3Eta', 'bcand4Eta', 'bcand5Eta', 'bcand6Eta', 'bcand1Phi', 'bcand2Phi', 'bcand3Phi', 'bcand4Phi', 'bcand5Phi', 'bcand6Phi']:
-        for var in ['h_fit_mass', 'h1_t3_mass', 'h2_t3_mass', 'h3_t3_mass', 'h1_t3_dRjets', 'h2_t3_dRjets', 'h3_t3_dRjets', 'bcand1Pt', 'bcand2Pt', 'bcand3Pt', 'bcand4Pt','bcand5Pt', 'bcand6Pt', 'bcand1Eta', 'bcand2Eta', 'bcand3Eta', 'bcand4Eta', 'bcand5Eta', 'bcand6Eta', 'jet1DeepFlavB','jet2DeepFlavB', 'jet3DeepFlavB', 'jet4DeepFlavB', 'jet5DeepFlavB','jet6DeepFlavB']:
-            self.reader.AddVariable(var,self.out._branches[var].buff)
-       
-        #self.reader.BookMVA("bdt","/isilon/data/users/mstamenk/hhh-6b-producer/CMSSW_11_1_0_pre5_PY3/src/hhh-bdt/dataset/weights/TMVAClassification_BDT.weights.xml")
-        #self.reader.BookMVA("bdt","/isilon/data/users/mstamenk/hhh-6b-producer/CMSSW_11_1_0_pre5_PY3/src/hhh-bdt/dataset-BTAG/weights/TMVAClassification_BDT.weights.xml")
-        self.reader.BookMVA("bdt",os.path.expandvars("$CMSSW_BASE/src/PhysicsTools/NanoAODTools/condor/bdt-xml/TMVAClassification_BDT.weights.xml"))
     def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         if self._opts['run_mass_regression'] and self._opts['WRITE_CACHE_FILE']:
             for p in self.pnMassRegressions:
@@ -873,7 +614,6 @@ class hhh6bProducerPNetAK4(Module):
                
     def selectLeptons(self, event):
         # do lepton selection
-        event.vbfLeptons = [] # usef for vbf removal
         event.looseLeptons = []  # used for lepton counting
         event.cleaningElectrons = []
         event.cleaningMuons = []
@@ -882,8 +622,6 @@ class hhh6bProducerPNetAK4(Module):
         electrons = Collection(event, "Electron")
         for el in electrons:
             el.Id = el.charge * (-11)
-            if el.pt > 7 and abs(el.eta) < 2.5 and abs(el.dxy) < 0.05 and abs(el.dz) < 0.2:
-                event.vbfLeptons.append(el)
             #if el.pt > 35 and abs(el.eta) <= 2.5 and el.miniPFRelIso_all <= 0.2 and el.cutBased:
             if el.pt > 35 and abs(el.eta) <= 2.5 and el.miniPFRelIso_all <= 0.2 and el.cutBased>3: # cutBased ID: (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)
                 event.looseLeptons.append(el)
@@ -897,8 +635,6 @@ class hhh6bProducerPNetAK4(Module):
         muons = Collection(event, "Muon")
         for mu in muons:
             mu.Id = mu.charge * (-13)
-            if mu.pt > 5 and abs(mu.eta) < 2.4 and abs(mu.dxy) < 0.05 and abs(mu.dz) < 0.2:
-                event.vbfLeptons.append(mu)
             if mu.pt > 30 and abs(mu.eta) <= 2.4 and mu.tightId and mu.miniPFRelIso_all <= 0.2:
                 event.looseLeptons.append(mu)
             if mu.pt > 30 and mu.looseId:
@@ -915,7 +651,6 @@ class hhh6bProducerPNetAK4(Module):
                     event.looseTaus.append(tau) # VVloose VsE, Tight vsMu, Medium Vsjet
 
         event.looseLeptons.sort(key=lambda x: x.pt, reverse=True)
-        event.vbfLeptons.sort(key=lambda x: x.pt, reverse=True)
         if self.Run==2:
             event.looseTaus.sort(key=lambda x: x.rawDeepTau2017v2p1VSjet, reverse=True)
         else:
@@ -1087,19 +822,6 @@ class hhh6bProducerPNetAK4(Module):
 
         event.ht = sum([j.pt for j in event.ak4jets])
 
-        # vbf
-        # for ak4: pick a pair of opposite eta jets that maximizes pT
-        # pT>25 GeV, |eta|<4.7, lepton cleaning event
-        event.vbffatjets = [fj for fj in event._ptFatJets if fj.pt > 200 and abs(fj.eta) < 2.4 and (fj.jetId & 2) and closest(fj, event.looseLeptons)[1] >= 0.8]
-        vbfjetid = 3 if self.year == "2017" else 2
-        if self.Run==2:
-            event.vbfak4jets = [j for j in event._allJets if j.pt > 25 and abs(j.eta) < 4.7 and (j.jetId >= vbfjetid) \
-                                and ( (j.pt < 50 and j.puId>=6) or (j.pt > 50) ) and closest(j, event.vbffatjets)[1] > 1.2 \
-                                and closest(j, event.vbfLeptons)[1] >= 0.4]
-        else:
-            event.vbfak4jets = [j for j in event._allJets if j.pt > 25 and abs(j.eta) < 4.7 and (j.jetId >= vbfjetid) \
-                                and closest(j, event.vbffatjets)[1] > 1.2 and closest(j, event.vbfLeptons)[1] >= 0.4]
-
         # b-tag AK4 jet selection - these jets don't have a kinematic selection
         event.bljets = []
         event.bmjets = []
@@ -1157,7 +879,6 @@ class hhh6bProducerPNetAK4(Module):
         # sort and select variations of jets
         if self._allJME:
             event.fatjetsJME = {}
-            event.vbfak4jetsJME = {}
             for syst in self._jmeLabels:
                 if syst == 'nominal': 
                     continue
@@ -1172,16 +893,6 @@ class hhh6bProducerPNetAK4(Module):
                 if syst == 'nominal':   
                     continue
                 """
-
-                vbffatjets_syst = [fj for fj in ptordered if fj.pt > 200 and abs(fj.eta) < 2.4 and (fj.jetId & 2) and closest(fj, event.looseLeptons)[1] >= 0.8]
-                vbfjetid = 3 if self.year == "2017" else 2
-                if self.Run==2:
-                    event.vbfak4jetsJME[syst] = [j for j in event._AllJets[syst] if j.pt > 25 and abs(j.eta) < 4.7 and (j.jetId >= vbfjetid) \
-                                                 and ( (j.pt < 50 and j.puId>=6) or (j.pt > 50) ) and closest(j, vbffatjets_syst)[1] > 1.2 \
-                                                 and closest(j, event.vbfLeptons)[1] >= 0.4]
-                else:
-                    event.vbfak4jetsJME[syst] = [j for j in event._AllJets[syst] if j.pt > 25 and abs(j.eta) < 4.7 and (j.jetId >= vbfjetid) \
-                                                 and closest(j, vbffatjets_syst)[1] > 1.2 and closest(j, event.vbfLeptons)[1] >= 0.4]
                 
     def evalMassRegression(self, event, jets):
         for i,j in enumerate(jets):
@@ -1323,31 +1034,9 @@ class hhh6bProducerPNetAK4(Module):
         if len(fatjets) > 0:
             h1Jet = polarP4(fatjets[0],mass='msoftdropJMS')
             h2Jet = polarP4(None)
-            h1Jet_reg = polarP4(fatjets[0],mass='regressed_massJMS')
-            h2Jet_reg = polarP4(None)
 
         if len(fatjets)>1:
             h2Jet = polarP4(fatjets[1],mass='msoftdropJMS')
-            h2Jet_reg = polarP4(fatjets[1],mass='regressed_massJMS')
-            self.out.fillBranch("hh_pt", (h1Jet+h2Jet).Pt())
-            self.out.fillBranch("hh_eta", (h1Jet+h2Jet).Eta())
-            self.out.fillBranch("hh_phi", (h1Jet+h2Jet).Phi())
-            self.out.fillBranch("hh_mass", (h1Jet+h2Jet).M())
-
-            self.out.fillBranch("hh_pt_MassRegressed", (h1Jet_reg+h2Jet_reg).Pt())
-            self.out.fillBranch("hh_eta_MassRegressed", (h1Jet_reg+h2Jet_reg).Eta())
-            self.out.fillBranch("hh_phi_MassRegressed", (h1Jet_reg+h2Jet_reg).Phi())
-            self.out.fillBranch("hh_mass_MassRegressed", (h1Jet_reg+h2Jet_reg).M())
-
-            self.out.fillBranch("deltaEta_j1j2", abs(h1Jet.Eta() - h2Jet.Eta()))
-            self.out.fillBranch("deltaPhi_j1j2", deltaPhi(fatjets[0], fatjets[1]))
-            self.out.fillBranch("deltaR_j1j2", deltaR(fatjets[0], fatjets[1]))
-            self.out.fillBranch("ptj2_over_ptj1", fatjets[1].pt/fatjets[0].pt)
-
-            mj2overmj1 = -1 if fatjets[0].regressed_massJMS<=0 else fatjets[1].regressed_massJMS/fatjets[0].regressed_massJMS
-            self.out.fillBranch("mj2_over_mj1", mj2overmj1)
-            mj2overmj1_reg = -1 if fatjets[0].msoftdropJMS<=0 else fatjets[1].msoftdropJMS/fatjets[0].msoftdropJMS
-            self.out.fillBranch("mj2_over_mj1_MassRegressed", mj2overmj1_reg)
 
             if self.isMC:
                 h1Jet_JMS_Down = polarP4(fatjets[0],mass='msoftdrop_JMS_Down')
@@ -1359,115 +1048,9 @@ class hhh6bProducerPNetAK4(Module):
                 h2Jet_JMR_Down = polarP4(fatjets[1],mass='msoftdrop_JMR_Down')
                 h1Jet_JMR_Up = polarP4(fatjets[0],mass='msoftdrop_JMR_Up')
                 h2Jet_JMR_Up = polarP4(fatjets[1],mass='msoftdrop_JMR_Up')
-    
-                self.out.fillBranch("hh_pt_JMS_Down", (h1Jet_JMS_Down+h2Jet_JMS_Down).Pt())
-                self.out.fillBranch("hh_eta_JMS_Down", (h1Jet_JMS_Down+h2Jet_JMS_Down).Eta())
-                self.out.fillBranch("hh_mass_JMS_Down", (h1Jet_JMS_Down+h2Jet_JMS_Down).M())
-                self.out.fillBranch("hh_pt_JMS_Up", (h1Jet_JMS_Up+h2Jet_JMS_Up).Pt())
-                self.out.fillBranch("hh_eta_JMS_Up", (h1Jet_JMS_Up+h2Jet_JMS_Up).Eta())
-                self.out.fillBranch("hh_mass_JMS_Up", (h1Jet_JMS_Up+h2Jet_JMS_Up).M())
-                
-                self.out.fillBranch("hh_pt_JMR_Down", (h1Jet_JMR_Down+h2Jet_JMR_Down).Pt())
-                self.out.fillBranch("hh_eta_JMR_Down", (h1Jet_JMR_Down+h2Jet_JMR_Down).Eta())
-                self.out.fillBranch("hh_mass_JMR_Down", (h1Jet_JMR_Down+h2Jet_JMR_Down).M())
-                self.out.fillBranch("hh_pt_JMR_Up", (h1Jet_JMR_Up+h2Jet_JMR_Up).Pt())
-                self.out.fillBranch("hh_eta_JMR_Up", (h1Jet_JMR_Up+h2Jet_JMR_Up).Eta())
-                self.out.fillBranch("hh_mass_JMR_Up", (h1Jet_JMR_Up+h2Jet_JMR_Up).M())
-
-                #h1Jet_reg_JMS_Down = polarP4(fatjets[0],mass='regressed_mass_JMS_Down')
-                #h2Jet_reg_JMS_Down = polarP4(fatjets[1],mass='regressed_mass_JMS_Down')
-                #h1Jet_reg_JMS_Up = polarP4(fatjets[0],mass='regressed_mass_JMS_Up')
-                #h2Jet_reg_JMS_Up = polarP4(fatjets[1],mass='regressed_mass_JMS_Up')
-
-                #h1Jet_reg_JMR_Down = polarP4(fatjets[0],mass='regressed_mass_JMR_Down')
-                #h2Jet_reg_JMR_Down = polarP4(fatjets[1],mass='regressed_mass_JMR_Down')
-                #h1Jet_reg_JMR_Up = polarP4(fatjets[0],mass='regressed_mass_JMR_Up')
-                #h2Jet_reg_JMR_Up = polarP4(fatjets[1],mass='regressed_mass_JMR_Up')
-                
-                #self.out.fillBranch("hh_pt_MassRegressed_JMS_Down", (h1Jet_reg_JMS_Down+h2Jet_reg_JMS_Down).Pt())
-                #self.out.fillBranch("hh_eta_MassRegressed_JMS_Down", (h1Jet_reg_JMS_Down+h2Jet_reg_JMS_Down).Eta())
-                #self.out.fillBranch("hh_mass_MassRegressed_JMS_Down", (h1Jet_reg_JMS_Down+h2Jet_reg_JMS_Down).M())
-                #self.out.fillBranch("hh_pt_MassRegressed_JMS_Up", (h1Jet_reg_JMS_Up+h2Jet_reg_JMS_Up).Pt())
-                #self.out.fillBranch("hh_eta_MassRegressed_JMS_Up", (h1Jet_reg_JMS_Up+h2Jet_reg_JMS_Up).Eta())
-                #self.out.fillBranch("hh_mass_MassRegressed_JMS_Up", (h1Jet_reg_JMS_Up+h2Jet_reg_JMS_Up).M())
-
-                #self.out.fillBranch("hh_pt_MassRegressed_JMR_Down", (h1Jet_reg_JMR_Down+h2Jet_reg_JMR_Down).Pt())
-                #self.out.fillBranch("hh_eta_MassRegressed_JMR_Down", (h1Jet_reg_JMR_Down+h2Jet_reg_JMR_Down).Eta())
-                #self.out.fillBranch("hh_mass_MassRegressed_JMR_Down", (h1Jet_reg_JMR_Down+h2Jet_reg_JMR_Down).M())
-                #self.out.fillBranch("hh_pt_MassRegressed_JMR_Up", (h1Jet_reg_JMR_Up+h2Jet_reg_JMR_Up).Pt())
-                #self.out.fillBranch("hh_eta_MassRegressed_JMR_Up", (h1Jet_reg_JMR_Up+h2Jet_reg_JMR_Up).Eta())
-                #self.out.fillBranch("hh_mass_MassRegressed_JMR_Up", (h1Jet_reg_JMR_Up+h2Jet_reg_JMR_Up).M())
-
-        else:
-            self.out.fillBranch("hh_pt", 0)
-            self.out.fillBranch("hh_eta", 0)
-            self.out.fillBranch("hh_phi", 0)
-            self.out.fillBranch("hh_mass", 0)
-            self.out.fillBranch("deltaEta_j1j2", 0)
-            self.out.fillBranch("deltaPhi_j1j2", 0)
-            self.out.fillBranch("deltaR_j1j2", 0)
-            self.out.fillBranch("ptj2_over_ptj1", 0)
-            self.out.fillBranch("mj2_over_mj1", 0)
-            if self.isMC:
-                self.out.fillBranch("hh_pt_JMS_Down",0)
-                self.out.fillBranch("hh_eta_JMS_Down",0)
-                self.out.fillBranch("hh_mass_JMS_Down",0)
-                self.out.fillBranch("hh_pt_JMS_Up", 0)
-                self.out.fillBranch("hh_eta_JMS_Up",0)
-                self.out.fillBranch("hh_mass_JMS_Up",0)
-                self.out.fillBranch("hh_pt_JMR_Down",0)
-                self.out.fillBranch("hh_eta_JMR_Down",0)
-                self.out.fillBranch("hh_mass_JMR_Down",0)
-                self.out.fillBranch("hh_pt_JMR_Up", 0)
-                self.out.fillBranch("hh_eta_JMR_Up",0)
-                self.out.fillBranch("hh_mass_JMR_Up",0)
-
-                self.out.fillBranch("hh_pt_MassRegressed_JMS_Down",0)
-                self.out.fillBranch("hh_eta_MassRegressed_JMS_Down",0)
-                self.out.fillBranch("hh_mass_MassRegressed_JMS_Down",0)
-                self.out.fillBranch("hh_pt_MassRegressed_JMS_Up", 0)
-                self.out.fillBranch("hh_eta_MassRegressed_JMS_Up",0)
-                self.out.fillBranch("hh_mass_MassRegressed_JMS_Up",0)
-                self.out.fillBranch("hh_pt_MassRegressed_JMR_Down",0)
-                self.out.fillBranch("hh_eta_MassRegressed_JMR_Down",0)
-                self.out.fillBranch("hh_mass_MassRegressed_JMR_Down",0)
-                self.out.fillBranch("hh_pt_MassRegressed_JMR_Up", 0)
-                self.out.fillBranch("hh_eta_MassRegressed_JMR_Up",0)
-                self.out.fillBranch("hh_mass_MassRegressed_JMR_Up",0)
 
         if len(fatjets)>2:
             h3Jet = polarP4(fatjets[2],mass='msoftdropJMS')
-            h3Jet_reg = polarP4(fatjets[2],mass='regressed_massJMS')
-            self.out.fillBranch("hhh_pt", (h1Jet+h2Jet+h3Jet).Pt())
-            self.out.fillBranch("hhh_eta", (h1Jet+h2Jet+h3Jet).Eta())
-            self.out.fillBranch("hhh_phi", (h1Jet+h2Jet+h3Jet).Phi())
-            self.out.fillBranch("hhh_mass", (h1Jet+h2Jet+h3Jet).M())
-
-            self.out.fillBranch("hhh_pt_MassRegressed", (h1Jet_reg+h2Jet_reg+h3Jet_reg).Pt())
-            self.out.fillBranch("hhh_eta_MassRegressed", (h1Jet_reg+h2Jet_reg+h3Jet_reg).Eta())
-            self.out.fillBranch("hhh_phi_MassRegressed", (h1Jet_reg+h2Jet_reg+h3Jet_reg).Phi())
-            self.out.fillBranch("hhh_mass_MassRegressed", (h1Jet_reg+h2Jet_reg+h3Jet_reg).M())
-
-            self.out.fillBranch("deltaEta_j1j3", abs(h1Jet.Eta() - h3Jet.Eta()))
-            self.out.fillBranch("deltaPhi_j1j3", deltaPhi(fatjets[0], fatjets[2]))
-            self.out.fillBranch("deltaEta_j2j3", abs(h2Jet.Eta() - h3Jet.Eta()))
-            self.out.fillBranch("deltaPhi_j2j3", deltaPhi(fatjets[1], fatjets[2]))
-
-            self.out.fillBranch("deltaR_j1j3", deltaR(fatjets[0], fatjets[2]))
-            self.out.fillBranch("deltaR_j2j3", deltaR(fatjets[1], fatjets[2]))
-
-            self.out.fillBranch("ptj3_over_ptj1", fatjets[2].pt/fatjets[0].pt)
-            self.out.fillBranch("ptj3_over_ptj2", fatjets[2].pt/fatjets[1].pt)
-
-            mj3overmj1 = -1 if fatjets[0].regressed_massJMS<=0 else fatjets[2].regressed_massJMS/fatjets[0].regressed_massJMS
-            self.out.fillBranch("mj3_over_mj1", mj3overmj1)
-            mj3overmj1_reg = -1 if fatjets[0].msoftdropJMS<=0 else fatjets[2].msoftdropJMS/fatjets[0].msoftdropJMS
-            self.out.fillBranch("mj3_over_mj1_MassRegressed", mj3overmj1_reg)
-
-            mj3overmj2 = -1 if fatjets[1].regressed_massJMS<=0 else fatjets[2].regressed_massJMS/fatjets[1].regressed_massJMS
-            self.out.fillBranch("mj3_over_mj2", mj3overmj2)
-            mj3overmj2_reg = -1 if fatjets[1].msoftdropJMS<=0 else fatjets[2].msoftdropJMS/fatjets[1].msoftdropJMS
-            self.out.fillBranch("mj3_over_mj2_MassRegressed", mj3overmj2_reg)
 
             if self.isMC:
                 h1Jet_JMS_Down = polarP4(fatjets[0],mass='msoftdrop_JMS_Down')
@@ -1485,87 +1068,6 @@ class hhh6bProducerPNetAK4(Module):
                 h1Jet_JMR_Up = polarP4(fatjets[0],mass='msoftdrop_JMR_Up')
                 h2Jet_JMR_Up = polarP4(fatjets[1],mass='msoftdrop_JMR_Up')
                 h3Jet_JMR_Up = polarP4(fatjets[2],mass='msoftdrop_JMR_Up')
-    
-                self.out.fillBranch("hhh_pt_JMS_Down", (h1Jet_JMS_Down+h2Jet_JMS_Down+h3Jet_JMS_Down).Pt())
-                self.out.fillBranch("hhh_eta_JMS_Down", (h1Jet_JMS_Down+h2Jet_JMS_Down+h3Jet_JMS_Down).Eta())
-                self.out.fillBranch("hhh_mass_JMS_Down", (h1Jet_JMS_Down+h2Jet_JMS_Down+h3Jet_JMS_Down).M())
-                self.out.fillBranch("hhh_pt_JMS_Up", (h1Jet_JMS_Up+h2Jet_JMS_Up+h3Jet_JMS_Up).Pt())
-                self.out.fillBranch("hhh_eta_JMS_Up", (h1Jet_JMS_Up+h2Jet_JMS_Up+h3Jet_JMS_Up).Eta())
-                self.out.fillBranch("hhh_mass_JMS_Up", (h1Jet_JMS_Up+h2Jet_JMS_Up+h3Jet_JMS_Up).M())
-                
-                self.out.fillBranch("hhh_pt_JMR_Down", (h1Jet_JMR_Down+h2Jet_JMR_Down+h3Jet_JMR_Down).Pt())
-                self.out.fillBranch("hhh_eta_JMR_Down", (h1Jet_JMR_Down+h2Jet_JMR_Down+h3Jet_JMR_Down).Eta())
-                self.out.fillBranch("hhh_mass_JMR_Down", (h1Jet_JMR_Down+h2Jet_JMR_Down+h3Jet_JMR_Down).M())
-                self.out.fillBranch("hhh_pt_JMR_Up", (h1Jet_JMR_Up+h2Jet_JMR_Up+h3Jet_JMR_Up).Pt())
-                self.out.fillBranch("hhh_eta_JMR_Up", (h1Jet_JMR_Up+h2Jet_JMR_Up+h3Jet_JMR_Up).Eta())
-                self.out.fillBranch("hhh_mass_JMR_Up", (h1Jet_JMR_Up+h2Jet_JMR_Up+h3Jet_JMR_Up).M())
-
-                #h1Jet_reg_JMS_Down = polarP4(fatjets[0],mass='regressed_mass_JMS_Down')
-                #h2Jet_reg_JMS_Down = polarP4(fatjets[1],mass='regressed_mass_JMS_Down')
-                #h1Jet_reg_JMS_Up = polarP4(fatjets[0],mass='regressed_mass_JMS_Up')
-                #h2Jet_reg_JMS_Up = polarP4(fatjets[1],mass='regressed_mass_JMS_Up')
-
-                #h1Jet_reg_JMR_Down = polarP4(fatjets[0],mass='regressed_mass_JMR_Down')
-                #h2Jet_reg_JMR_Down = polarP4(fatjets[1],mass='regressed_mass_JMR_Down')
-                #h1Jet_reg_JMR_Up = polarP4(fatjets[0],mass='regressed_mass_JMR_Up')
-                #h2Jet_reg_JMR_Up = polarP4(fatjets[1],mass='regressed_mass_JMR_Up')
-                
-                #self.out.fillBranch("hh_pt_MassRegressed_JMS_Down", (h1Jet_reg_JMS_Down+h2Jet_reg_JMS_Down).Pt())
-                #self.out.fillBranch("hh_eta_MassRegressed_JMS_Down", (h1Jet_reg_JMS_Down+h2Jet_reg_JMS_Down).Eta())
-                #self.out.fillBranch("hh_mass_MassRegressed_JMS_Down", (h1Jet_reg_JMS_Down+h2Jet_reg_JMS_Down).M())
-                #self.out.fillBranch("hh_pt_MassRegressed_JMS_Up", (h1Jet_reg_JMS_Up+h2Jet_reg_JMS_Up).Pt())
-                #self.out.fillBranch("hh_eta_MassRegressed_JMS_Up", (h1Jet_reg_JMS_Up+h2Jet_reg_JMS_Up).Eta())
-                #self.out.fillBranch("hh_mass_MassRegressed_JMS_Up", (h1Jet_reg_JMS_Up+h2Jet_reg_JMS_Up).M())
-
-                #self.out.fillBranch("hh_pt_MassRegressed_JMR_Down", (h1Jet_reg_JMR_Down+h2Jet_reg_JMR_Down).Pt())
-                #self.out.fillBranch("hh_eta_MassRegressed_JMR_Down", (h1Jet_reg_JMR_Down+h2Jet_reg_JMR_Down).Eta())
-                #self.out.fillBranch("hh_mass_MassRegressed_JMR_Down", (h1Jet_reg_JMR_Down+h2Jet_reg_JMR_Down).M())
-                #self.out.fillBranch("hh_pt_MassRegressed_JMR_Up", (h1Jet_reg_JMR_Up+h2Jet_reg_JMR_Up).Pt())
-                #self.out.fillBranch("hh_eta_MassRegressed_JMR_Up", (h1Jet_reg_JMR_Up+h2Jet_reg_JMR_Up).Eta())
-                #self.out.fillBranch("hh_mass_MassRegressed_JMR_Up", (h1Jet_reg_JMR_Up+h2Jet_reg_JMR_Up).M())
-
-        else:
-            self.out.fillBranch("hhh_pt", 0)
-            self.out.fillBranch("hhh_eta", 0)
-            self.out.fillBranch("hhh_phi", 0)
-            self.out.fillBranch("hhh_mass", 0)
-            self.out.fillBranch("deltaEta_j1j3", 0)
-            self.out.fillBranch("deltaPhi_j1j3", 0)
-            self.out.fillBranch("deltaR_j1j3", 0)
-            self.out.fillBranch("deltaEta_j2j3", 0)
-            self.out.fillBranch("deltaPhi_j2j3", 0)
-            self.out.fillBranch("deltaR_j2j3", 0)
-
-            self.out.fillBranch("ptj3_over_ptj1", 0)
-            self.out.fillBranch("mj3_over_mj1", 0)
-            self.out.fillBranch("ptj3_over_ptj2", 0)
-            self.out.fillBranch("mj3_over_mj2", 0)
-            if self.isMC:
-                self.out.fillBranch("hhh_pt_JMS_Down",0)
-                self.out.fillBranch("hhh_eta_JMS_Down",0)
-                self.out.fillBranch("hhh_mass_JMS_Down",0)
-                self.out.fillBranch("hhh_pt_JMS_Up", 0)
-                self.out.fillBranch("hhh_eta_JMS_Up",0)
-                self.out.fillBranch("hhh_mass_JMS_Up",0)
-                self.out.fillBranch("hhh_pt_JMR_Down",0)
-                self.out.fillBranch("hhh_eta_JMR_Down",0)
-                self.out.fillBranch("hhh_mass_JMR_Down",0)
-                self.out.fillBranch("hhh_pt_JMR_Up", 0)
-                self.out.fillBranch("hhh_eta_JMR_Up",0)
-                self.out.fillBranch("hhh_mass_JMR_Up",0)
-
-                self.out.fillBranch("hhh_pt_MassRegressed_JMS_Down",0)
-                self.out.fillBranch("hhh_eta_MassRegressed_JMS_Down",0)
-                self.out.fillBranch("hhh_mass_MassRegressed_JMS_Down",0)
-                self.out.fillBranch("hhh_pt_MassRegressed_JMS_Up", 0)
-                self.out.fillBranch("hhh_eta_MassRegressed_JMS_Up",0)
-                self.out.fillBranch("hhh_mass_MassRegressed_JMS_Up",0)
-                self.out.fillBranch("hhh_pt_MassRegressed_JMR_Down",0)
-                self.out.fillBranch("hhh_eta_MassRegressed_JMR_Down",0)
-                self.out.fillBranch("hhh_mass_MassRegressed_JMR_Down",0)
-                self.out.fillBranch("hhh_pt_MassRegressed_JMR_Up", 0)
-                self.out.fillBranch("hhh_eta_MassRegressed_JMR_Up",0)
-                self.out.fillBranch("hhh_mass_MassRegressed_JMR_Up",0)
 
 
         #for idx in ([1, 2, 3, 4, 5, 6, 7 ,8 , 9, 10]):
@@ -1585,7 +1087,6 @@ class hhh6bProducerPNetAK4(Module):
                     fill_fj(prefix + "Mass", fj.mass*fj.particleNet_massCorr)
                 else: # Crash when trying to do "None*None"
                     fill_fj(prefix + "Mass", fj.mass)
-            fill_fj(prefix + "MassRegressed_UnCorrected", fj.regressed_mass)
             fill_fj(prefix + "MassSD_UnCorrected", fj.msoftdrop)
             fill_fj(prefix + "PNetXbb", fj.Xbb)
             fill_fj(prefix + "PNetXjj", fj.Xjj)
@@ -1599,11 +1100,6 @@ class hhh6bProducerPNetAK4(Module):
                 fill_fj(prefix + "HiggsMatchedIndex", fj.HiggsMatchIndex)
                 fill_fj(prefix + "MatchedGenPt", fj.MatchedGenPt)
 
-            #fill_fj(prefix + "PNetQCDb", fj.particleNetMD_QCDb)
-            #fill_fj(prefix + "PNetQCDbb", fj.particleNetMD_QCDbb)
-            #fill_fj(prefix + "PNetQCDc", fj.particleNetMD_QCDc)
-            #fill_fj(prefix + "PNetQCDcc", fj.particleNetMD_QCDcc)
-            #fill_fj(prefix + "PNetQCDothers", fj.particleNetMD_QCDothers)
             fill_fj(prefix + "Tau3OverTau2", fj.t32)
             
             # uncertainties
@@ -1614,16 +1110,9 @@ class hhh6bProducerPNetAK4(Module):
                 fill_fj(prefix + "MassSD_JMS_Up",  fj.msoftdrop_JMS_Up)
                 fill_fj(prefix + "MassSD_JMR_Down", fj.msoftdrop_JMR_Down)
                 fill_fj(prefix + "MassSD_JMR_Up",  fj.msoftdrop_JMR_Up)
-
-                #fill_fj(prefix + "MassRegressed", fj.regressed_mass_corr)
-                #fill_fj(prefix + "MassRegressed_JMS_Down", fj.regressed_mass_JMS_Down)
-                #fill_fj(prefix + "MassRegressed_JMS_Up",   fj.regressed_mass_JMS_Up)
-                #fill_fj(prefix + "MassRegressed_JMR_Down", fj.regressed_mass_JMR_Down)
-                #fill_fj(prefix + "MassRegressed_JMR_Up", fj.regressed_mass_JMR_Up)
             else:
                 fill_fj(prefix + "MassSD_noJMS", fj.msoftdrop)
                 fill_fj(prefix + "MassSD", fj.msoftdropJMS)
-                fill_fj(prefix + "MassRegressed", fj.regressed_massJMS)
             
             # lepton variables
             if fj:
@@ -1665,14 +1154,8 @@ class hhh6bProducerPNetAK4(Module):
                 else:
                     # print('hh mass 0?',(h1Jet+h2Jet).M())
                     fill_fj(prefix + "PtOverMHH", -1)
-                if (h1Jet_reg+h2Jet_reg).M()>0:
-                    fill_fj(prefix + "PtOverMHH_MassRegressed", fj.pt/(h1Jet_reg+h2Jet_reg).M())
-                else:
-                    # print('hh reg mass 0?',(h1Jet_reg+h2Jet_reg).M())
-                    fill_fj(prefix + "PtOverMHH_MassRegressed", -1)
             else:
                 fill_fj(prefix + "PtOverMHH", -1)
-                fill_fj(prefix + "PtOverMHH_MassRegressed", -1)
             fill_fj(prefix + "PtOverMSD", ptovermsd)
             fill_fj(prefix + "PtOverMRegressed", ptovermregressed)
 
@@ -1682,11 +1165,6 @@ class hhh6bProducerPNetAK4(Module):
                     fill_fj(prefix + "PtOverMHH_JMS_Up", fj.pt/(h1Jet_JMS_Up+h2Jet_JMS_Up).M())
                     fill_fj(prefix + "PtOverMHH_JMR_Down", fj.pt/(h1Jet_JMR_Down+h2Jet_JMR_Down).M())
                     fill_fj(prefix + "PtOverMHH_JMR_Up", fj.pt/(h1Jet_JMR_Up+h2Jet_JMR_Up).M())
-
-                    #fill_fj(prefix + "PtOverMHH_MassRegressed_JMS_Down", fj.pt/(h1Jet_reg_JMS_Down+h2Jet_reg_JMS_Down).M())
-                    #fill_fj(prefix + "PtOverMHH_MassRegressed_JMS_Up", fj.pt/(h1Jet_reg_JMS_Up+h2Jet_reg_JMS_Up).M())
-                    #fill_fj(prefix + "PtOverMHH_MassRegressed_JMR_Down", fj.pt/(h1Jet_reg_JMR_Down+h2Jet_reg_JMR_Down).M())
-                    #fill_fj(prefix + "PtOverMHH_MassRegressed_JMR_Up", fj.pt/(h1Jet_reg_JMR_Up+h2Jet_reg_JMR_Up).M())
                 else:
                     fill_fj(prefix + "PtOverMHH_JMS_Down",0)
                     fill_fj(prefix + "PtOverMHH_JMS_Up", 0)
@@ -1700,17 +1178,9 @@ class hhh6bProducerPNetAK4(Module):
 
     def fillFatJetInfoJME(self, event, fatjets):
         if not self._allJME or not self.isMC: return
-        #if len(fatjets)>=2:
-        #    h1Jet = polarP4(fatjets[0],mass='regressed_massJMS')
-        #    h2Jet = polarP4(fatjets[1],mass='regressed_massJMS')
-        #    print('fatjets hh_mass %.4f jet1pt %.4f jet2pt %.4f'%((h1Jet+h2Jet).M(),fatjets[0].pt,fatjets[1].pt))
         for syst in self._jmeLabels:
             if syst == 'nominal': continue
             if len(event.fatjetsJME[syst]) < 2 or len(fatjets)<2: 
-                self.out.fillBranch("hh_pt" + "_" + syst, 0)
-                self.out.fillBranch("hh_eta" + "_" + syst, 0)
-                self.out.fillBranch("hh_mass" + "_" + syst, 0)
-                self.out.fillBranch("hh_mass_MassRegressed" + "_" + syst, 0)
                 for idx in ([1, 2]):
                     prefix = 'fatJet%i' % idx
                     self.out.fillBranch(prefix + "Pt" + "_" + syst, 0)
@@ -1718,12 +1188,6 @@ class hhh6bProducerPNetAK4(Module):
             else:
                 h1Jet = polarP4(event.fatjetsJME[syst][0],mass='msoftdropJMS')
                 h2Jet = polarP4(event.fatjetsJME[syst][1],mass='msoftdropJMS')
-                self.out.fillBranch("hh_pt" + "_" + syst, (h1Jet+h2Jet).Pt())
-                self.out.fillBranch("hh_eta" + "_" + syst, (h1Jet+h2Jet).Eta())
-                self.out.fillBranch("hh_mass" + "_" + syst, (h1Jet+h2Jet).M())
-                h1Jet_reg = polarP4(event.fatjetsJME[syst][0],mass='regressed_massJMS')
-                h2Jet_reg = polarP4(event.fatjetsJME[syst][1],mass='regressed_massJMS')
-                self.out.fillBranch("hh_mass_MassRegressed" + "_" + syst, (h1Jet_reg+h2Jet_reg).M())
 
                 """
                 if 'EC2' in syst and ((event.fatjetsJME[syst][0].pt!=fatjets[0].pt) or (event.fatjetsJME[syst][1].pt!=fatjets[1].pt)):
@@ -1810,492 +1274,9 @@ class hhh6bProducerPNetAK4(Module):
             hadGenH_4vec = [polarP4(h) for h in self.hadGenHs]
             genHdaughter_4vec = [polarP4(d) for d in self.genHdaughter]
 
-        # Techniques 1 & 2: Require 6 AK4 jets
-        # Actually these are obsolete compared to technique 3 which considers AK4 & AK8
-        if len(jets_4vec) > 5:
-            jets_4vec = jets_4vec[:6]
-            #if self.nFatJets == 0:
-            #    if len(jets_4vec) == 6:
-
-            # Technique 1: simple chi2
-            permutations = list(itertools.permutations(jets_4vec))
-            permutations = [el[:6] for el in permutations]
-            permutations = list(set(permutations))
-
-            min_chi2 = 1000000000000000
-            for permutation in permutations:
-                j0_tmp = permutation[0]
-                j1_tmp = permutation[1]
-
-                j2_tmp = permutation[2]
-                j3_tmp = permutation[3]
-
-                j4_tmp = permutation[4]
-                j5_tmp = permutation[5]
-
-
-                h1_tmp = j0_tmp + j1_tmp
-                h2_tmp = j2_tmp + j3_tmp
-                h3_tmp = j4_tmp + j5_tmp
-
-                chi2 = 0
-                for h in [h1_tmp, h2_tmp, h3_tmp]:
-                    chi2 += (h.M() - 125.0)**2
-
-                if chi2 < min_chi2:
-                    min_chi2 = chi2
-                    if h1_tmp.Pt() > h2_tmp.Pt():
-                        if h1_tmp.Pt() > h3_tmp.Pt():
-                            h1 = h1_tmp
-                            if j0_tmp.Pt() > j1_tmp.Pt():
-                                j0 = j0_tmp
-                                j1 = j1_tmp
-                            else:
-                                j0 = j1_tmp
-                                j1 = j0_tmp
-
-                            if h2_tmp.Pt() > h3_tmp.Pt():
-                                h2 = h2_tmp
-                                if j2_tmp.Pt() > j3_tmp.Pt():
-                                    j2 = j2_tmp 
-                                    j3 = j3_tmp
-                                else:
-                                    j2 = j3_tmp
-                                    j3 = j2_tmp
-
-                                h3 = h3_tmp
-                                if j4_tmp.Pt() > j5_tmp.Pt():
-                                    j4 = j4_tmp
-                                    j5 = j5_tmp
-                                else:
-                                    j4 = j5_tmp
-                                    j5 = j4_tmp
-                            else:
-                                h2 = h3_tmp
-                                if j4_tmp.Pt() > j5_tmp.Pt():
-                                    j2 = j4_tmp
-                                    j3 = j5_tmp
-                                else:
-                                    j2 = j5_tmp
-                                    j3 = j4_tmp
-
-                                h3 = h2_tmp
-                                if j2_tmp.Pt() > j3_tmp.Pt():
-                                    j4 = j2_tmp
-                                    j5 = j3_tmp
-                                else:
-                                    j4 = j3_tmp
-                                    j5 = j2_tmp
-                        else:
-                            h1 = h3_tmp
-                            if j4_tmp.Pt() > j5_tmp.Pt():
-                                j0 = j4_tmp
-                                j1 = j5_tmp
-                            else:
-                                j0 = j5_tmp
-                                j1 = j4_tmp
-
-                            h2 = h1_tmp
-                            if j0_tmp.Pt() > j1_tmp.Pt():
-                                j2 = j0_tmp
-                                j3 = j1_tmp
-                            else:
-                                j2 = j1_tmp
-                                j3 = j0_tmp
-                            h3 = h2_tmp
-                            if j2_tmp.Pt() > j3_tmp.Pt():
-                                j4 = j2_tmp
-                                j5 = j3_tmp
-                            else:
-                                j4 = j3_tmp
-                                j5 = j2_tmp
-                    else:
-                        if h1_tmp.Pt() > h3_tmp.Pt():
-                            h1 = h2_tmp
-                            if j2_tmp.Pt() > j3_tmp.Pt():
-                                j0 = j2_tmp
-                                j1 = j3_tmp
-                            else:
-                                j0 = j3_tmp
-                                j1 = j2_tmp
-
-                            h2 = h1_tmp
-                            if j0_tmp.Pt() > j1_tmp.Pt():
-                                j2 = j0_tmp
-                                j3 = j1_tmp
-                            else:
-                                j2 = j1_tmp
-                                j3 = j0_tmp
-
-                            h3 = h3_tmp
-                            if j4_tmp.Pt() > j5_tmp.Pt():
-                                j4 = j4_tmp
-                                j5 = j5_tmp
-                            else:
-                                j4 = j5_tmp
-                                j5 = j4_tmp
-                        else:
-                            h3 = h1_tmp
-                            if j0_tmp.Pt() > j1_tmp.Pt():
-                                j4 = j0_tmp
-                                j5 = j1_tmp
-                            else:
-                                j4 = j1_tmp
-                                j5 = j0_tmp
-
-                            if h2_tmp.Pt() > h3_tmp.Pt():
-                                h1 = h2_tmp
-                                if j2_tmp.Pt() > j3_tmp.Pt():
-                                    j0 = j2_tmp
-                                    j1 = j3_tmp
-                                else:
-                                    j0 = j3_tmp
-                                    j1 = j2_tmp
-                                h2 = h3_tmp
-                                if j4_tmp.Pt() > j5_tmp.Pt():
-                                    j2 = j4_tmp
-                                    j3 = j5_tmp
-                                else:
-                                    j2 = j5_tmp
-                                    j3 = j4_tmp
-                            else:
-                                h1 = h3_tmp
-                                if j4_tmp.Pt() > j5_tmp.Pt():
-                                    j0 = j4_tmp
-                                    j1 = j5_tmp
-                                else:
-                                    j0 = j5_tmp
-                                    j1 = j4_tmp
-
-                                h2 = h2_tmp
-                                if j2_tmp.Pt() > j3_tmp.Pt():
-                                    j2 = j2_tmp
-                                    j3 = j3_tmp
-                                else:
-                                    j2 = j3_tmp
-                                    j3 = j2_tmp
-
-
-            # truth matching 
-            matchH1 = False
-            matchH2 = False
-            matchH3 = False
-            matched = 0 
-
-            #for j in [j0,j1,j2,j3,j4,j5]:
-            #    j.matchH = False
-
-            #for dau in genHdaughter_4vec:
-            #    for j in [j0,j1,j2,j3,j4,j5]:
-            #        if deltaR(dau.eta(),dau.phi(),j.eta(),j.phi()) < 0.4:
-            #            matched += 1
-            #            j.matchH = True
-            #print("Match fillJetInfo", matched)
-            if j0.HiggsMatch == True and j1.HiggsMatch == True and j0.HiggsMatchIndex == j1.HiggsMatchIndex:
-                matchH1 = True
-                #print("Matched H1")
-
-            if j2.HiggsMatch == True and j3.HiggsMatch == True and j2.HiggsMatchIndex == j3.HiggsMatchIndex:
-                matchH2 = True
-                #print("Matched H2")
-
-            if j4.HiggsMatch == True and j5.HiggsMatch == True and j4.HiggsMatchIndex == j5.HiggsMatchIndex:
-                matchH3 = True
-                #print("Matched H3")
-
-            if self.isMC:
-                self.out.fillBranch("ngenvistau",event.nGenVisTau)
-            #self.out.fillBranch('nsignaltaus',len(event.looseTaus)) # This is the same as "ntaus"
-                       
-            self.out.fillBranch("h1_mass", h1.M())
-            self.out.fillBranch("h1_pt", h1.Pt())
-            self.out.fillBranch("h1_eta", h1.Eta())
-            self.out.fillBranch("h1_phi", h1.Phi())
-            self.out.fillBranch("h1_match", matchH1)
-
-            self.out.fillBranch("h2_mass", h2.M())
-            self.out.fillBranch("h2_pt", h2.Pt())
-            self.out.fillBranch("h2_eta", h2.Eta())
-            self.out.fillBranch("h2_phi", h2.Phi())
-            self.out.fillBranch("h2_match", matchH2)
-
-            self.out.fillBranch("h3_mass", h3.M())
-            self.out.fillBranch("h3_pt", h3.Pt())
-            self.out.fillBranch("h3_eta", h3.Eta())
-            self.out.fillBranch("h3_phi", h3.Phi())
-            self.out.fillBranch("h3_match", matchH3)
-
-            self.out.fillBranch("hhh_resolved_mass", (h1+h2+h3).M())
-            self.out.fillBranch("hhh_resolved_pt", (h1+h2+h3).Pt())
-
-            self.out.fillBranch("h1h2_mass_squared", (h1+h2).M() * (h1+h2).M())
-            self.out.fillBranch("h2h3_mass_squared", (h2+h3).M() * (h2+h3).M())
-
-
-            # Technique 2: mass mH1 as reference
-
-            permutations = list(itertools.permutations(jets_4vec))
-            permutations = [el[:6] for el in permutations]
-            permutations = list(set(permutations))
-
-            min_chi2 = 1000000000000000
-            for permutation in permutations:
-                j0_tmp = permutation[0]
-                j1_tmp = permutation[1]
-
-                j2_tmp = permutation[2]
-                j3_tmp = permutation[3]
-
-                j4_tmp = permutation[4]
-                j5_tmp = permutation[5]
-
-                h1_tmp = j0_tmp + j1_tmp
-                h2_tmp = j2_tmp + j3_tmp
-                h3_tmp = j4_tmp + j5_tmp
-
-                chi2 = 0
-                #for h in [h1_tmp, h2_tmp, h3_tmp]:
-                #    chi2 += (h.M() - 125.0)**2
-                higgs_tmp = [h1_tmp, h2_tmp, h3_tmp]
-                higgs_tmp.sort(key= lambda x: x.Pt(), reverse=True)
-                h1_tmp = higgs_tmp[0]
-                h2_tmp = higgs_tmp[1]
-                h3_tmp = higgs_tmp[2]
-
-
-                if chi2 < min_chi2:
-                    min_chi2 = chi2
-                    if h1_tmp.Pt() > h2_tmp.Pt():
-                        if h1_tmp.Pt() > h3_tmp.Pt():
-                            h1 = h1_tmp
-                            if j0_tmp.Pt() > j1_tmp.Pt():
-                                j0 = j0_tmp
-                                j1 = j1_tmp
-                            else:
-                                j0 = j1_tmp
-                                j1 = j0_tmp
-
-                            if h2_tmp.Pt() > h3_tmp.Pt():
-                                h2 = h2_tmp
-                                if j2_tmp.Pt() > j3_tmp.Pt():
-                                    j2 = j2_tmp 
-                                    j3 = j3_tmp
-                                else:
-                                    j2 = j3_tmp
-                                    j3 = j2_tmp
-
-                                h3 = h3_tmp
-                                if j4_tmp.Pt() > j5_tmp.Pt():
-                                    j4 = j4_tmp
-                                    j5 = j5_tmp
-                                else:
-                                    j4 = j5_tmp
-                                    j5 = j4_tmp
-                            else:
-                                h2 = h3_tmp
-                                if j4_tmp.Pt() > j5_tmp.Pt():
-                                    j2 = j4_tmp
-                                    j3 = j5_tmp
-                                else:
-                                    j2 = j5_tmp
-                                    j3 = j4_tmp
-
-                                h3 = h2_tmp
-                                if j2_tmp.Pt() > j3_tmp.Pt():
-                                    j4 = j2_tmp
-                                    j5 = j3_tmp
-                                else:
-                                    j4 = j3_tmp
-                                    j5 = j2_tmp
-                        else:
-                            h1 = h3_tmp
-                            if j4_tmp.Pt() > j5_tmp.Pt():
-                                j0 = j4_tmp
-                                j1 = j5_tmp
-                            else:
-                                j0 = j5_tmp
-                                j1 = j4_tmp
-
-                            h2 = h1_tmp
-                            if j0_tmp.Pt() > j1_tmp.Pt():
-                                j2 = j0_tmp
-                                j3 = j1_tmp
-                            else:
-                                j2 = j1_tmp
-                                j3 = j0_tmp
-                            h3 = h2_tmp
-                            if j2_tmp.Pt() > j3_tmp.Pt():
-                                j4 = j2_tmp
-                                j5 = j3_tmp
-                            else:
-                                j4 = j3_tmp
-                                j5 = j2_tmp
-                    else:
-                        if h1_tmp.Pt() > h3_tmp.Pt():
-                            h1 = h2_tmp
-                            if j2_tmp.Pt() > j3_tmp.Pt():
-                                j0 = j2_tmp
-                                j1 = j3_tmp
-                            else:
-                                j0 = j3_tmp
-                                j1 = j2_tmp
-
-                            h2 = h1_tmp
-                            if j0_tmp.Pt() > j1_tmp.Pt():
-                                j2 = j0_tmp
-                                j3 = j1_tmp
-                            else:
-                                j2 = j1_tmp
-                                j3 = j0_tmp
-
-                            h3 = h3_tmp
-                            if j4_tmp.Pt() > j5_tmp.Pt():
-                                j4 = j4_tmp
-                                j5 = j5_tmp
-                            else:
-                                j4 = j5_tmp
-                                j5 = j4_tmp
-                        else:
-                            h3 = h1_tmp
-                            if j0_tmp.Pt() > j1_tmp.Pt():
-                                j4 = j0_tmp
-                                j5 = j1_tmp
-                            else:
-                                j4 = j1_tmp
-                                j5 = j0_tmp
-
-                            if h2_tmp.Pt() > h3_tmp.Pt():
-                                h1 = h2_tmp
-                                if j2_tmp.Pt() > j3_tmp.Pt():
-                                    j0 = j2_tmp
-                                    j1 = j3_tmp
-                                else:
-                                    j0 = j3_tmp
-                                    j1 = j2_tmp
-                                h2 = h3_tmp
-                                if j4_tmp.Pt() > j5_tmp.Pt():
-                                    j2 = j4_tmp
-                                    j3 = j5_tmp
-                                else:
-                                    j2 = j5_tmp
-                                    j3 = j4_tmp
-                            else:
-                                h1 = h3_tmp
-                                if j4_tmp.Pt() > j5_tmp.Pt():
-                                    j0 = j4_tmp
-                                    j1 = j5_tmp
-                                else:
-                                    j0 = j5_tmp
-                                    j1 = j4_tmp
-
-                                h2 = h2_tmp
-                                if j2_tmp.Pt() > j3_tmp.Pt():
-                                    j2 = j2_tmp
-                                    j3 = j3_tmp
-                                else:
-                                    j2 = j3_tmp
-                                    j3 = j2_tmp
-            # kin fit
-            #fitted_nll, fitted_mass = fitMass(h1.M(),15., h2.M(), 15., h3.M(), 15.)
-
-            # truth matching 
-            matchH1 = False
-            matchH2 = False
-            matchH3 = False
-            matched = 0 
-
-            #for j in [j0,j1,j2,j3,j4,j5]:
-            #    j.matchH = False
-
-            #for dau in genHdaughter_4vec:
-            #    for j in [j0,j1,j2,j3,j4,j5]:
-            #        if deltaR(dau.eta(),dau.phi(),j.eta(),j.phi()) < 0.4:
-            #            matched += 1
-            #            j.matchH = True
-            #print("Match fillJetInfo", matched)
-            if j0.HiggsMatch == True and j1.HiggsMatch == True and j0.HiggsMatchIndex == j1.HiggsMatchIndex:
-                matchH1 = True
-                #print("Matched H1")
-
-            if j2.HiggsMatch == True and j3.HiggsMatch == True and j2.HiggsMatchIndex == j3.HiggsMatchIndex:
-                matchH2 = True
-                #print("Matched H2")
-
-            if j4.HiggsMatch == True and j5.HiggsMatch == True and j4.HiggsMatchIndex == j5.HiggsMatchIndex:
-                matchH3 = True
-                #print("Matched H3")
-
-            # fill variables
-            #self.out.fillBranch("h_fit_mass", fitted_mass)
-                        
-            self.out.fillBranch("h1_t2_mass", h1.M())
-            self.out.fillBranch("h1_t2_pt", h1.Pt())
-            self.out.fillBranch("h1_t2_eta", h1.Eta())
-            self.out.fillBranch("h1_t2_phi", h1.Phi())
-            self.out.fillBranch("h1_t2_match", matchH1)
-            self.out.fillBranch("h1_t2_dRjets", deltaR(j0.eta(),j0.phi(),j1.eta(),j1.phi()))
-
-            self.out.fillBranch("h2_t2_mass", h2.M())
-            self.out.fillBranch("h2_t2_pt", h2.Pt())
-            self.out.fillBranch("h2_t2_eta", h2.Eta())
-            self.out.fillBranch("h2_t2_phi", h2.Phi())
-            self.out.fillBranch("h2_t2_match", matchH2)
-            self.out.fillBranch("h2_t2_dRjets", deltaR(j2.eta(),j2.phi(),j3.eta(),j3.phi()))
-
-            self.out.fillBranch("h3_t2_mass", h3.M())
-            self.out.fillBranch("h3_t2_pt", h3.Pt())
-            self.out.fillBranch("h3_t2_eta", h3.Eta())
-            self.out.fillBranch("h3_t2_phi", h3.Phi())
-            self.out.fillBranch("h3_t2_match", matchH3)
-            self.out.fillBranch("h3_t2_dRjets", deltaR(j4.eta(),j4.phi(),j5.eta(),j5.phi()))
-
-        else:
-            self.out.fillBranch("h1_mass", -1)
-            self.out.fillBranch("h1_pt", -1)
-            self.out.fillBranch("h1_eta", -1)
-            self.out.fillBranch("h1_phi", -1)
-            #self.out.fillBranch("h1_match", -1)
-
-            self.out.fillBranch("h2_mass", -1)
-            self.out.fillBranch("h2_pt", -1)
-            self.out.fillBranch("h2_eta", -1)
-            self.out.fillBranch("h2_phi", -1)
-            #self.out.fillBranch("h2_match", -1)
-
-            self.out.fillBranch("h3_mass", -1)
-            self.out.fillBranch("h3_pt", -1)
-            self.out.fillBranch("h3_eta", -1)
-            self.out.fillBranch("h3_phi", -1)
-            #self.out.fillBranch("h3_match", -1)
-
-            self.out.fillBranch("h1_t2_mass", -1)
-            self.out.fillBranch("h1_t2_pt", -1)
-            self.out.fillBranch("h1_t2_eta", -1)
-            self.out.fillBranch("h1_t2_phi", -1)
-            #self.out.fillBranch("h1_t2_match", -1)
-
-            self.out.fillBranch("h2_t2_mass", -1)
-            self.out.fillBranch("h2_t2_pt", -1)
-            self.out.fillBranch("h2_t2_eta", -1)
-            self.out.fillBranch("h2_t2_phi", -1)
-            #self.out.fillBranch("h2_t2_match", -1)
-
-            self.out.fillBranch("h3_t2_mass", -1)
-            self.out.fillBranch("h3_t2_pt", -1)
-            self.out.fillBranch("h3_t2_eta", -1)
-            self.out.fillBranch("h3_t2_phi", -1)
-            #self.out.fillBranch("h3_t2_match", -1)
-
-            self.out.fillBranch("hhh_resolved_mass",-1)
-            self.out.fillBranch("hhh_resolved_pt", -1)
-
-            self.out.fillBranch("h1h2_mass_squared", -1)
-            self.out.fillBranch("h2h3_mass_squared", -1)
-
 
         if len(jets)+2*len(fatjets) > 5:
             # Technique 3: mass fitter
-            
             m_fit,h1,h2,h3,j0,j1,j2,j3,j4,j5 = self.higgsPairingAlgorithm(event,jets,fatjets,XbbWP)
                        
             self.out.fillBranch("h1_t3_mass", h1.Mass)
@@ -2329,40 +1310,7 @@ class hhh6bProducerPNetAK4(Module):
 
             self.out.fillBranch("h_fit_mass", m_fit)
 
-            dic_bcands = {1: j0, 
-                          2: j1,
-                          3: j2,
-                          4: j3,
-                          5: j4,
-                          6: j5,
-                    }
-
-            for idx in ([1, 2, 3, 4, 5, 6]):
-                prefix = 'bcand%i'%idx
-                self.out.fillBranch(prefix + "Pt", dic_bcands[idx].Pt())
-                self.out.fillBranch(prefix + "Eta", abs(dic_bcands[idx].Eta()))
-                self.out.fillBranch(prefix + "Phi", dic_bcands[idx].Phi())
-                self.out.fillBranch(prefix + "DeepFlavB", dic_bcands[idx].btagDeepFlavB)
-                self.out.fillBranch(prefix + "PNetB", dic_bcands[idx].btagPNetB)
-                self.out.fillBranch(prefix + "JetId", dic_bcands[idx].jetId)
-                self.out.fillBranch(prefix + "Mass", dic_bcands[idx].mass)
-                self.out.fillBranch(prefix + "RawFactor", dic_bcands[idx].rawFactor)
-                if self.Run==2:
-                    self.out.fillBranch(prefix + "PuId", dic_bcands[idx].puId)
-                    self.out.fillBranch(prefix + "bRegCorr", dic_bcands[idx].bRegCorr)
-                    self.out.fillBranch(prefix + "bRegRes", dic_bcands[idx].bRegRes)
-                    self.out.fillBranch(prefix + "cRegCorr", dic_bcands[idx].cRegCorr)
-                    self.out.fillBranch(prefix + "cRegRes", dic_bcands[idx].cRegRes)
-                if self.isMC:
-                    self.out.fillBranch(prefix + "HiggsMatched", dic_bcands[idx].HiggsMatch)
-                    self.out.fillBranch(prefix + "HiggsMatchedIndex", dic_bcands[idx].HiggsMatchIndex)
-                    self.out.fillBranch(prefix + "HadronFlavour", dic_bcands[idx].hadronFlavour)
-                    self.out.fillBranch(prefix + "MatchedGenPt", dic_bcands[idx].MatchedGenPt)
-
-
-
         else:
-
             self.out.fillBranch("h1_t3_mass", -1)
             self.out.fillBranch("h1_t3_pt", -1)
             self.out.fillBranch("h1_t3_eta", -1)
@@ -2383,53 +1331,6 @@ class hhh6bProducerPNetAK4(Module):
 
             self.out.fillBranch("h_fit_mass", -1)
 
-        #print(self.reader.EvaluateMVA("BDT"))
-        self.out.fillBranch("bdt", self.reader.EvaluateMVA("bdt"))
-
-
-
-    def fillVBFFatJetInfo(self, event, fatjets):
-        for idx in ([1, 2]):
-            fj = fatjets[idx-1] if len(fatjets)>idx-1 else _NullObject()
-            prefix = 'vbffatJet%i' % (idx)
-            fillBranch = self._get_filler(fj)
-            fillBranch(prefix + "Pt", fj.pt)
-            fillBranch(prefix + "Eta", fj.eta)
-            fillBranch(prefix + "Phi", fj.phi)
-            fillBranch(prefix + "PNetXbb", fj.Xbb)
-            
-    def fillVBFJetInfo(self, event, jets):
-        for idx in ([1, 2]):
-            j = jets[idx-1]if len(jets)>idx-1 else _NullObject()
-            prefix = 'vbfjet%i' % (idx)
-            fillBranch = self._get_filler(j)
-            fillBranch(prefix + "Pt", j.pt)
-            fillBranch(prefix + "Eta", j.eta)
-            fillBranch(prefix + "Phi", j.phi)
-            fillBranch(prefix + "Mass", j.mass)
-
-        isVBFtag = 0
-        if len(jets)>1:
-            Jet1 = polarP4(jets[0])
-            Jet2 = polarP4(jets[1])
-            isVBFtag = 0
-            if((Jet1+Jet2).M() > 500. and abs(Jet1.Eta() - Jet2.Eta()) > 4): isVBFtag = 1
-            self.out.fillBranch('dijetmass', (Jet1+Jet2).M())
-        else:
-            self.out.fillBranch('dijetmass', 0)
-        self.out.fillBranch('isVBFtag', isVBFtag)
-
-    def fillVBFJetInfoJME(self, event, jets):
-        if not self._allJME or not self.isMC: return
-        for syst in self._jmeLabels:
-            if syst == 'nominal': continue
-            isVBFtag = 0
-            if len(event.vbfak4jetsJME[syst])>1 and len(jets)>1:
-                Jet1 = polarP4(event.vbfak4jetsJME[syst][0])
-                Jet2 = polarP4(event.vbfak4jetsJME[syst][1])
-                isVBFtag = 0
-                if((Jet1+Jet2).M() > 500. and abs(Jet1.Eta() - Jet2.Eta()) > 4): isVBFtag = 1
-            self.out.fillBranch('isVBFtag' + "_" + syst, isVBFtag)
             
     def fillLeptonInfo(self, event, leptons):
         for idx in ([1, 2]):
@@ -2493,19 +1394,13 @@ class hhh6bProducerPNetAK4(Module):
         dummyHiggs.phi = -1
         dummyHiggs.dRjets = 0.
 
-
-        #probejets = [fj for fj in fatjets if fj.pt > 250 and fj.Xbb > XbbWP]
         probejets = [fj for fj in fatjets]
         probetau = []
         if dotaus:
-          #probetau = sorted([fj for fj in fatjets if fj.pt > 250 and fj.Xtautau > XtautauWP], key=lambda x: x.Xtautau, reverse = True)
           probetau = sorted([fj for fj in fatjets and fj.Xtautau > XtautauWP], key=lambda x: x.Xtautau, reverse = True)
           if len(probetau)>0:
             probetau = probetau[0]
-            #probejets = [fj for fj in probejets if fj!=probetau]
 
-
-        #jets_4vec = [polarP4(j) for j in jets]
         jets_4vec = []
         for j in jets:
             overlap = False
@@ -2567,10 +1462,6 @@ class hhh6bProducerPNetAK4(Module):
                 taus_4vec.append(t_tmp)
 
 
-        #print(len(probejets),"Probejets:",probejets)
-        #print("Probetau:",probetau)
-        #print(len(jets_4vec),"AK4 jets:",jets_4vec)
-        #print(len(taus_4vec),"Taus:",taus_4vec)
         if len(jets_4vec) > 5:
             jets_4vec = jets_4vec[:6]
 
@@ -2589,7 +1480,6 @@ class hhh6bProducerPNetAK4(Module):
 
         # 3 AK8 jets
         if len(probejets) > 2:
-            #print("HAVE 3 PROBEJETS")
             h1 = probejets[0]
             h2 = probejets[1]
             h3 = probejets[2]
@@ -2763,7 +1653,6 @@ class hhh6bProducerPNetAK4(Module):
             h3.matchH3 = False
             if j0.HiggsMatch == True and j1.HiggsMatch == True and j0.HiggsMatchIndex == j1.HiggsMatchIndex:
                 h3.matchH3 = True
-                #print("Matched H1")
 
 
         elif len(probejets) == 1:
@@ -2827,7 +1716,6 @@ class hhh6bProducerPNetAK4(Module):
                     h2.matchH2 = False
                     if j0.HiggsMatch == True and j1.HiggsMatch == True and j0.HiggsMatchIndex == j1.HiggsMatchIndex:
                         h2.matchH2 = True
-                        #print("Matched H1")
                     if not dotaus:
                         event.reco6b_1bh1h = True
                         event.reco6b_Idx = 6
@@ -2947,7 +1835,6 @@ class hhh6bProducerPNetAK4(Module):
                     h2.matchH2 = False
                     if j0.HiggsMatch == True and j1.HiggsMatch == True and j0.HiggsMatchIndex == j1.HiggsMatchIndex:
                         h2.matchH2 = True
-                        #print("Matched H1")
                     event.reco4b2t_1bh1h = True
                     event.reco4b2t_Idx = 6
                     return m_fit,h1,h2,dummyHiggs,j0,j1,j2,j3,j4,j5
@@ -2996,7 +1883,6 @@ class hhh6bProducerPNetAK4(Module):
                     h2.matchH2 = False
                     if j0.HiggsMatch == True and j1.HiggsMatch == True and j0.HiggsMatchIndex == j1.HiggsMatchIndex:
                         h2.matchH2 = True
-                        #print("Matched H1")
                     event.reco4b2t_1bh1h = True
                     event.reco4b2t_Idx = 6
                     event.reco4b2t_TauIsResolved = 2
@@ -3055,7 +1941,6 @@ class hhh6bProducerPNetAK4(Module):
             h2.matchH2 = False
             if j0.HiggsMatch == True and j1.HiggsMatch == True and j0.HiggsMatchIndex == j1.HiggsMatchIndex:
                 h2.matchH2 = True
-                #print("Matched H1")
 
             h3.Mass = h3.M()
             h3.pt = h3.Pt()
@@ -3064,11 +1949,9 @@ class hhh6bProducerPNetAK4(Module):
             h3.matchH3 = False
             if j2.HiggsMatch == True and j3.HiggsMatch == True and j2.HiggsMatchIndex == j3.HiggsMatchIndex:
                 h3.matchH3 = True
-                #print("Matched H2")
 
         else: 
 
-            #if (not dotaus and len(jets_4vec) > 5) or (dotaus and len(jets_4vec) > 3 and len(taus_4vec) > 1):
             if len(jets_4vec) < 2 and len(taus_4vec) < 2:
                 if not dotaus:
                     event.reco6b_0bh0h = True
@@ -3078,9 +1961,6 @@ class hhh6bProducerPNetAK4(Module):
                     event.reco4b2t_Idx = 0
                 return 0,dummyHiggs,dummyHiggs,dummyHiggs,j0,j1,j2,j3,j4,j5
             else:
-                #jets_4vec = jets_4vec[:6]
-                #if self.nFatJets == 0:
-                #    if len(jets_4vec) == 6:
 
                 # Technique 3: mass fit
                 jpermutations = list(itertools.permutations(jets_4vec))
@@ -3145,12 +2025,7 @@ class hhh6bProducerPNetAK4(Module):
                             h_tmp.append(dummyHiggs)
 
                     if len(h_tmpgood)==0: continue # Can still happen if we have only Taus and charge requirement is failed
-                    #h1_tmp = j0_tmp + j1_tmp
-                    #h2_tmp = j2_tmp + j3_tmp
-                    #h3_tmp = j4_tmp + j5_tmp
 
-                    #fitted_mass = (h1_tmp.M() + h2_tmp.M() + h3_tmp.M())/3.
-                    #chi2 = (h1_tmp.M() - fitted_mass)**2 + (h2_tmp.M() - fitted_mass)**2 + (h3_tmp.M() - fitted_mass)**2
                     fitted_mass = 0.0
                     for h in h_tmpgood:
                         fitted_mass += h.M()
@@ -3228,7 +2103,7 @@ class hhh6bProducerPNetAK4(Module):
                                     j4 = j3_tmp
                                     j5 = j2_tmp
                         else:
-                            if h_tmp[0].Pt() > h_tmp[2].Pt():# or dotaus:
+                            if h_tmp[0].Pt() > h_tmp[2].Pt():
                                 h1 = h_tmp[1]
                                 if j2_tmp.Pt() > j3_tmp.Pt():
                                     j0 = j2_tmp
@@ -3261,7 +2136,7 @@ class hhh6bProducerPNetAK4(Module):
                                     j4 = j1_tmp
                                     j5 = j0_tmp
 
-                                if h_tmp[1].Pt() > h_tmp[2].Pt():# or dotaus:
+                                if h_tmp[1].Pt() > h_tmp[2].Pt():
                                     h1 = h_tmp[1]
                                     if j2_tmp.Pt() > j3_tmp.Pt():
                                         j0 = j2_tmp
@@ -3309,7 +2184,6 @@ class hhh6bProducerPNetAK4(Module):
                     h1.matchH1 = False
                     if j0.HiggsMatch == True and j1.HiggsMatch == True and j0.HiggsMatchIndex == j1.HiggsMatchIndex:
                         h1.matchH1 = True
-                        #print("Matched H1")
 
                 if h2==dummyHiggs:
                     if not dotaus:
@@ -3328,7 +2202,6 @@ class hhh6bProducerPNetAK4(Module):
                     h2.matchH2 = False
                     if j2.HiggsMatch == True and j3.HiggsMatch == True and j2.HiggsMatchIndex == j3.HiggsMatchIndex:
                         h2.matchH2 = True
-                        #print("Matched H2")
 
                 if h3==dummyHiggs:
                     if not dotaus:
@@ -3348,7 +2221,6 @@ class hhh6bProducerPNetAK4(Module):
                     h3.matchH3 = False
                     if j4.HiggsMatch == True and j5.HiggsMatch == True and j4.HiggsMatchIndex == j5.HiggsMatchIndex:
                         h3.matchH3 = True
-                        #print("Matched H3")
 
                     if not dotaus:
                         event.reco6b_0bh3h = True
@@ -3360,8 +2232,6 @@ class hhh6bProducerPNetAK4(Module):
                         elif j2.DeepTauVsJet != -1: event.reco4b2t_TauIsResolved = 2
                         elif j4.DeepTauVsJet != -1: event.reco4b2t_TauIsResolved = 3
 
-        #print("6b FS:",9*event.reco6b_0bh1h+8*event.reco6b_1bh0h+7*event.reco6b_0bh2h+6*event.reco6b_1bh1h+5*event.reco6b_2bh0h+4*event.reco6b_0bh3h+3*event.reco6b_1bh2h+2*event.reco6b_2bh1h+event.reco6b_3bh0h)
-        #print("4b2t FS:",9*event.reco4b2t_0bh1h+8*event.reco4b2t_1bh0h+7*event.reco4b2t_0bh2h+6*event.reco4b2t_1bh1h+5*event.reco4b2t_2bh0h+4*event.reco4b2t_0bh3h+3*event.reco4b2t_1bh2h+2*event.reco4b2t_2bh1h+event.reco4b2t_3bh0h)
         return m_fit,h1,h2,h3,j0,j1,j2,j3,j4,j5
 
     def fillTriggerFilters(self, event):
@@ -3440,10 +2310,10 @@ class hhh6bProducerPNetAK4(Module):
             probe_jets = [fj for fj in event.fatjets if (fj.pt > 200 and fj.t32<0.54)]
             if len(probe_jets) < 1:
                 return False
-        elif self._opts['option'] == "21":
-            probe_jets = [fj for fj in event.vbffatjets if fj.pt > 200]
-            if len(probe_jets) < 1:
-                return False
+        #elif self._opts['option'] == "21":
+        #    probe_jets = [fj for fj in event.vbffatjets if fj.pt > 200]
+        #    if len(probe_jets) < 1:
+        #        return False
         #else:
         #    if len(probe_jets) < 2:
         #        return False
@@ -3555,9 +2425,6 @@ class hhh6bProducerPNetAK4(Module):
         except IndexError:
             return False
 
-        self.fillVBFFatJetInfo(event, event.vbffatjets)
-        self.fillVBFJetInfo(event, event.vbfak4jets)
-        self.fillVBFJetInfoJME(event, event.vbfak4jets)
         self.fillLeptonInfo(event, event.looseLeptons)
         self.fillTauInfo(event, event.looseTaus)
  

--- a/python/producers/hhh6bProducerPNetAK4.py
+++ b/python/producers/hhh6bProducerPNetAK4.py
@@ -1809,6 +1809,9 @@ class hhh6bProducerPNetAK4(Module):
         if self.isMC:
             hadGenH_4vec = [polarP4(h) for h in self.hadGenHs]
             genHdaughter_4vec = [polarP4(d) for d in self.genHdaughter]
+
+        # Techniques 1 & 2: Require 6 AK4 jets
+        # Actually these are obsolete compared to technique 3 which considers AK4 & AK8
         if len(jets_4vec) > 5:
             jets_4vec = jets_4vec[:6]
             #if self.nFatJets == 0:
@@ -2246,8 +2249,51 @@ class hhh6bProducerPNetAK4(Module):
             self.out.fillBranch("h3_t2_match", matchH3)
             self.out.fillBranch("h3_t2_dRjets", deltaR(j4.eta(),j4.phi(),j5.eta(),j5.phi()))
 
+        else:
+            self.out.fillBranch("h1_mass", -1)
+            self.out.fillBranch("h1_pt", -1)
+            self.out.fillBranch("h1_eta", -1)
+            self.out.fillBranch("h1_phi", -1)
+            #self.out.fillBranch("h1_match", -1)
+
+            self.out.fillBranch("h2_mass", -1)
+            self.out.fillBranch("h2_pt", -1)
+            self.out.fillBranch("h2_eta", -1)
+            self.out.fillBranch("h2_phi", -1)
+            #self.out.fillBranch("h2_match", -1)
+
+            self.out.fillBranch("h3_mass", -1)
+            self.out.fillBranch("h3_pt", -1)
+            self.out.fillBranch("h3_eta", -1)
+            self.out.fillBranch("h3_phi", -1)
+            #self.out.fillBranch("h3_match", -1)
+
+            self.out.fillBranch("h1_t2_mass", -1)
+            self.out.fillBranch("h1_t2_pt", -1)
+            self.out.fillBranch("h1_t2_eta", -1)
+            self.out.fillBranch("h1_t2_phi", -1)
+            #self.out.fillBranch("h1_t2_match", -1)
+
+            self.out.fillBranch("h2_t2_mass", -1)
+            self.out.fillBranch("h2_t2_pt", -1)
+            self.out.fillBranch("h2_t2_eta", -1)
+            self.out.fillBranch("h2_t2_phi", -1)
+            #self.out.fillBranch("h2_t2_match", -1)
+
+            self.out.fillBranch("h3_t2_mass", -1)
+            self.out.fillBranch("h3_t2_pt", -1)
+            self.out.fillBranch("h3_t2_eta", -1)
+            self.out.fillBranch("h3_t2_phi", -1)
+            #self.out.fillBranch("h3_t2_match", -1)
+
+            self.out.fillBranch("hhh_resolved_mass",-1)
+            self.out.fillBranch("hhh_resolved_pt", -1)
+
+            self.out.fillBranch("h1h2_mass_squared", -1)
+            self.out.fillBranch("h2h3_mass_squared", -1)
 
 
+        if len(jets)+2*len(fatjets) > 5:
             # Technique 3: mass fitter
             
             m_fit,h1,h2,h3,j0,j1,j2,j3,j4,j5 = self.higgsPairingAlgorithm(event,jets,fatjets)
@@ -2314,42 +2360,8 @@ class hhh6bProducerPNetAK4(Module):
                     self.out.fillBranch(prefix + "MatchedGenPt", dic_bcands[idx].MatchedGenPt)
 
 
+
         else:
-            self.out.fillBranch("h1_mass", -1)
-            self.out.fillBranch("h1_pt", -1)
-            self.out.fillBranch("h1_eta", -1)
-            self.out.fillBranch("h1_phi", -1)
-            #self.out.fillBranch("h1_match", -1)
-
-            self.out.fillBranch("h2_mass", -1)
-            self.out.fillBranch("h2_pt", -1)
-            self.out.fillBranch("h2_eta", -1)
-            self.out.fillBranch("h2_phi", -1)
-            #self.out.fillBranch("h2_match", -1)
-
-            self.out.fillBranch("h3_mass", -1)
-            self.out.fillBranch("h3_pt", -1)
-            self.out.fillBranch("h3_eta", -1)
-            self.out.fillBranch("h3_phi", -1)
-            #self.out.fillBranch("h3_match", -1)
-
-            self.out.fillBranch("h1_t2_mass", -1)
-            self.out.fillBranch("h1_t2_pt", -1)
-            self.out.fillBranch("h1_t2_eta", -1)
-            self.out.fillBranch("h1_t2_phi", -1)
-            #self.out.fillBranch("h1_t2_match", -1)
-
-            self.out.fillBranch("h2_t2_mass", -1)
-            self.out.fillBranch("h2_t2_pt", -1)
-            self.out.fillBranch("h2_t2_eta", -1)
-            self.out.fillBranch("h2_t2_phi", -1)
-            #self.out.fillBranch("h2_t2_match", -1)
-
-            self.out.fillBranch("h3_t2_mass", -1)
-            self.out.fillBranch("h3_t2_pt", -1)
-            self.out.fillBranch("h3_t2_eta", -1)
-            self.out.fillBranch("h3_t2_phi", -1)
-            #self.out.fillBranch("h3_t2_match", -1)
 
             self.out.fillBranch("h1_t3_mass", -1)
             self.out.fillBranch("h1_t3_pt", -1)
@@ -2370,12 +2382,6 @@ class hhh6bProducerPNetAK4(Module):
             #self.out.fillBranch("h3_t3_match", -1)
 
             self.out.fillBranch("h_fit_mass", -1)
-
-            self.out.fillBranch("hhh_resolved_mass",-1)
-            self.out.fillBranch("hhh_resolved_pt", -1)
-
-            self.out.fillBranch("h1h2_mass_squared", -1)
-            self.out.fillBranch("h2h3_mass_squared", -1)
 
         #print(self.reader.EvaluateMVA("BDT"))
         self.out.fillBranch("bdt", self.reader.EvaluateMVA("bdt"))


### PR DESCRIPTION
Additions for 4b2tau:
- Adding code for FastMTT algorithm
- Branches for fourth FatJet are saved
- Saving up to 4 Taus and 4 leptons (El/Mu)
- Higgs-Pairing algorithm runs twice: Once for 6b and once for 4b2tau; and also puts results in separate branches
- New branches:
  - nprobetaus (equivalent to "nprobejets" variable", but passing Xtautau instead of Xbb)
  - PNet AK8 discriminators for taus (Xtautau, Xtaumu, Xtaue and Xtauany)
  - Tau and Lepton charge, genmatched pT, HiggsMatched / FatJetMatched variables
  - Decay mode of Gen Higgses (-5*5 for bb)
  - Index of reconstructable Higgs categories (separate for 6b and 4b2t)
  - Branch on which reconstructed Higgs is the Htautau, and if it's boosted or resolved

Changes maybe affecting 6b:
- Higgs-Pairing algorithm: No priority is given to FatJets, if other possible combinations lead to better fitted mass (but still removing AK4 jets overlapping with FatJets). Other changes as well affecting the overall logic/strategy
- Definition of loose electrons and muons is updated, and now explicilty removing AK4 jets overlapping with Leptons and Taus (To be considered: Is the lepton-veto JetID still needed in this case?)
- eta requirement for FatJets increase from <2.4 to <2.5
- AK4 jets must pass PNet b-tagging WP (currently set to "Tight" for Run3, nothing for Run2 done yet)
- FatJets ("probe_jets") have pT > 215 GeV cut
- Higgs/FatJet matching is done for jets and taus (This by itself shouldn't cause any change if jets are now separated from Taus)