### PR TITLE
Further updates, mostly for 4b2tau

### DIFF
--- a/python/helpers/higgsPairingAlgorithm_v2.py
+++ b/python/helpers/higgsPairingAlgorithm_v2.py
@@ -23,7 +23,7 @@ def manualPermutation(input1, input2, input3=[0]):
           output.append([v1,v2])
   return output
 
-def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, dotaus=False, taus=[], XtautauWP=0.0, METvars=[]):
+def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, jetdicsr, jetWP, dotaus=False, taus=[], TauVsEl=1, TauVsMu=1, TauVsJet=1, XtautauWP=0.0, leptons=[], METvars=[]):
 
     # save jets properties
     dummyJet = polarP4()
@@ -38,6 +38,7 @@ def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, dotaus=Fals
     dummyJet.hadronFlavour = -1
     dummyJet.jetId = -1
     dummyJet.puId = -1
+    dummyJet.pdgId = -1
     dummyJet.rawFactor = -1
     dummyJet.bRegCorr = -1
     dummyJet.bRegRes = -1
@@ -47,17 +48,15 @@ def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, dotaus=Fals
     dummyJet.mass = 0.
 
     dummyHiggs = polarP4()
-    dummyHiggs.matchH1 = False
-    dummyHiggs.matchH2 = False
-    dummyHiggs.matchH3 = False
+    dummyHiggs.matchH = 0
     dummyHiggs.mass = 0.
     dummyHiggs.Mass = 0.
-    dummyHiggs.pt = -1
-    dummyHiggs.eta = -1
-    dummyHiggs.phi = -1
-    dummyHiggs.dRjets = 0.
+    dummyHiggs.pt = -99.
+    dummyHiggs.eta = -99.
+    dummyHiggs.phi = -99.
+    dummyHiggs.dRjets = -1.
 
-    probetau = sorted([fj for fj in fatjets if fj.Xtautau > XtautauWP], key=lambda x: x.Xtautau, reverse = True)
+    probetau = sorted([fj for fj in fatjets if fj.Xtauany > XtautauWP], key=lambda x: x.Xtauany, reverse = True)
     if len(probetau)>0:
         probetau = probetau[0]
     probejets = sorted([fj for fj in fatjets if fj.Xbb > XbbWP and fj!=probetau], key=lambda x: x.Xbb, reverse = True)
@@ -87,11 +86,126 @@ def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, dotaus=Fals
         covMET[1][1] = METvars[4]
 
 
+    leptons_4vec = []
+    for l in leptons:
+        overlap = False
+        for fj in probejets:
+            if deltaR(l,fj) < 0.8: overlap = True
+        if overlap == False:
+            l_tmp = polarP4(l)
+            l_tmp.HiggsMatch = l.HiggsMatch
+            l_tmp.HiggsMatchIndex = l.HiggsMatchIndex
+            l_tmp.FatJetMatch = l.FatJetMatch
+            l_tmp.charge = l.charge
+            l_tmp.btagDeepFlavB = -1
+            l_tmp.btagPNetB = -1
+            l_tmp.kind = l.kind
+            l_tmp.DM = -1
+            l_tmp.DeepTauVsJet = -1
+            if isMC:
+                l_tmp.hadronFlavour = -1
+            l_tmp.jetId = -1
+            l_tmp.pdgId = l.Id
+            l_tmp.rawFactor = -1
+            l_tmp.mass = l.mass
+            l_tmp.MatchedGenPt = l.MatchedGenPt
+            if Run==2:
+                l_tmp.puId = -1
+                l_tmp.bRegCorr = -1
+                l_tmp.bRegRes = -1
+                l_tmp.cRegCorr = -1
+                l_tmp.cRegRes = -1
+
+            leptons_4vec.append(l_tmp)
+
+    if len(leptons_4vec) > 4:
+        leptons_4vec = leptons_4vec[:4]
+
+    taus_4vec = []
+    for t in taus:
+        if Run==2:
+            if t.rawDeepTau2017v2p1VSe < TauVsEl: continue
+            if t.rawDeepTau2017v2p1VSmu < TauVsMu: continue
+            if t.rawDeepTau2017v2p1VSjet < TauVsJet: continue
+        else:
+            if t.rawDeepTau2018v2p5VSe < TauVsEl: continue
+            if t.rawDeepTau2018v2p5VSmu < TauVsMu: continue
+            if t.rawDeepTau2018v2p5VSjet < TauVsJet: continue
+        overlap = False
+        for fj in probejets:
+            if deltaR(t,fj) < 0.8: overlap = True
+        for l in leptons_4vec:
+            if deltaR(t.eta,t.phi,l.Eta(),l.Phi()) < 0.4: overlap = True
+        if overlap == False:
+            t_tmp = polarP4(t)
+            t_tmp.HiggsMatch = t.HiggsMatch
+            t_tmp.HiggsMatchIndex = t.HiggsMatchIndex
+            t_tmp.FatJetMatch = t.FatJetMatch
+            t_tmp.charge = t.charge
+            t_tmp.btagDeepFlavB = -1
+            t_tmp.btagPNetB = -1
+            t_tmp.kind = t.kind
+            t_tmp.DM = t.decayMode
+            if Run==2:
+                t_tmp.DeepTauVsJet = t.rawDeepTau2017v2p1VSjet
+            else:
+                t_tmp.DeepTauVsJet = t.rawDeepTau2018v2p5VSjet
+            if isMC:
+                t_tmp.hadronFlavour = -1
+            t_tmp.jetId = -1
+            t_tmp.pdgId = t.Id
+            t_tmp.rawFactor = -1
+            t_tmp.mass = t.mass
+            t_tmp.MatchedGenPt = t.MatchedGenPt
+            if Run==2:
+                t_tmp.puId = -1
+                t_tmp.bRegCorr = -1
+                t_tmp.bRegRes = -1
+                t_tmp.cRegCorr = -1
+                t_tmp.cRegRes = -1
+
+            taus_4vec.append(t_tmp)
+
+    if len(taus_4vec) > 4:
+        taus_4vec = taus_4vec[:4]
+
+    if dotaus:
+      taulepton_4vec = taus_4vec+leptons_4vec
+    else:
+      taulepton_4vec = []
+    taupairs = []
+    for i1,t1 in enumerate(taulepton_4vec):
+      for i2,t2 in enumerate(taulepton_4vec):
+        if i2<=i1: continue
+        if t1.charge * t2.charge >= 0: continue
+        tau1 = ROOT.MeasuredTauLepton(t1.kind, t1.Pt(), t1.Eta(), t1.Phi(), t1.mass, t1.DM)
+        tau2 = ROOT.MeasuredTauLepton(t2.kind, t2.Pt(), t2.Eta(), t2.Phi(), t2.mass, t2.DM)
+        VectorOfTaus = ROOT.std.vector('MeasuredTauLepton')
+        bothtaus = VectorOfTaus()
+        bothtaus.push_back(tau1)
+        bothtaus.push_back(tau2)
+        FMTT = ROOT.FastMTT()
+        FMTT.run(bothtaus, MET_x, MET_y, covMET)
+        FMTToutput = FMTT.getBestP4()
+        FastMTTmass = FMTToutput.M()
+        taupairs.append((i1,i2,(t1+t2),t1.DeepTauVsJet*t2.DeepTauVsJet,"Tau",FastMTTmass,t1.pdgId*t2.pdgId)) # IdxTau/Lep1, IdxTau/Lep2, RecoHiggs, Comb.DeepTauScore, "Tau", RecoHiggsMass, TauFinalState
+    #taupairs = sorted([p for p in taupairs], key=lambda x: x[3], reverse = True)
+    taupairs_tautau = sorted([p for p in taupairs if p[6]==-15*15], key=lambda x: x[3], reverse = True) # All TauTau pairs, sorted by factor of both VSjet scores
+    taupairs_leptau = sorted([p for p in taupairs if p[6] in [-13*15,-11*15]], key=lambda x: x[3], reverse = False) # All LepTau pairs, sorted by the Tau's VSjet score (values are all negative, because of the *(-1) of the lepton)
+    taupairs_leplep = [p for p in taupairs if p[6] in [-11*13,-13*13,-11*11]] # All e-mu/mu-mu/e-e pairs. Not sorted, so should be sorted by pT already
+    taupairs = taupairs_tautau + taupairs_leptau + taupairs_leplep # Merge like this
+
+
     jets_4vec = []
     for j in jets:
+        if jetdicsr!="":
+            if getattr(j, jetdicsr) < jetWP: continue
         overlap = False
         for fj in probejets:
             if deltaR(j,fj) < 0.8: overlap = True
+        for t in taus_4vec:
+            if deltaR(j.eta,j.phi,t.Eta(),t.Phi()) < 0.4: overlap = True
+        # Jet-Lepton overlap already done before
         if overlap == False:
             j_tmp = polarP4(j)
             j_tmp.HiggsMatch = j.HiggsMatch
@@ -105,6 +219,7 @@ def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, dotaus=Fals
             if isMC:
                 j_tmp.hadronFlavour = j.hadronFlavour
             j_tmp.jetId = j.jetId
+            j_tmp.pdgId = -1
             j_tmp.rawFactor = j.rawFactor
             j_tmp.mass = j.mass
             j_tmp.MatchedGenPt = j.MatchedGenPt
@@ -124,63 +239,9 @@ def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, dotaus=Fals
     for i1,j1 in enumerate(jets_4vec):
       for i2,j2 in enumerate(jets_4vec):
         if i2<=i1: continue
-        jetpairs.append((i1,i2,(j1+j2),j1.btagPNetB*j2.btagPNetB,"Jet",(j1+j2).M()))
+        jetpairs.append((i1,i2,(j1+j2),j1.btagPNetB*j2.btagPNetB,"Jet",(j1+j2).M())) # IdxJet1, IdxJet2, RecoHiggs, Comb.BtagScore, "Jet", RecoHiggsMass
     jetpairs = sorted([p for p in jetpairs], key=lambda x: x[3], reverse = True)
 
-    taus_4vec = []
-    for t in taus:
-        overlap = False
-        for fj in probejets:
-            if deltaR(t,fj) < 0.8: overlap = True
-        if overlap == False:
-            t_tmp = polarP4(t)
-            t_tmp.HiggsMatch = t.HiggsMatch
-            t_tmp.HiggsMatchIndex = t.HiggsMatchIndex
-            t_tmp.FatJetMatch = t.FatJetMatch
-            t_tmp.charge = t.charge
-            t_tmp.btagDeepFlavB = -1
-            t_tmp.btagPNetB = -1
-            t_tmp.kind = t.kind
-            t_tmp.DM = t.decayMode
-            if Run==2:
-                t_tmp.DeepTauVsJet = t.rawDeepTau2017v2p1VSjet
-            else:
-                t_tmp.DeepTauVsJet = t.rawDeepTau2018v2p5VSjet
-            if isMC:
-                t_tmp.hadronFlavour = -1
-            t_tmp.jetId = -1
-            t_tmp.rawFactor = -1
-            t_tmp.mass = t.mass
-            t_tmp.MatchedGenPt = t.MatchedGenPt
-            if Run==2:
-                t_tmp.puId = -1
-                t_tmp.bRegCorr = -1
-                t_tmp.bRegRes = -1
-                t_tmp.cRegCorr = -1
-                t_tmp.cRegRes = -1
-
-            taus_4vec.append(t_tmp)
-
-    if len(taus_4vec) > 4:
-        taus_4vec = taus_4vec[:4]
-
-    taupairs = []
-    for i1,t1 in enumerate(taus_4vec):
-      for i2,t2 in enumerate(taus_4vec):
-        if i2<=i1: continue
-        if t1.charge * t2.charge >= 0: continue
-        tau1 = ROOT.MeasuredTauLepton(t1.kind, t1.Pt(), t1.Eta(), t1.Phi(), t1.mass, t1.DM)
-        tau2 = ROOT.MeasuredTauLepton(t2.kind, t2.Pt(), t2.Eta(), t2.Phi(), t2.mass, t2.DM)
-        VectorOfTaus = ROOT.std.vector('MeasuredTauLepton')
-        bothtaus = VectorOfTaus()
-        bothtaus.push_back(tau1)
-        bothtaus.push_back(tau2)
-        FMTT = ROOT.FastMTT()
-        FMTT.run(bothtaus, MET_x, MET_y, covMET)
-        FMTToutput = FMTT.getBestP4()
-        FastMTTmass = FMTToutput.M()
-        taupairs.append((i1,i2,(t1+t2),t1.DeepTauVsJet*t2.DeepTauVsJet,"Tau",FastMTTmass))
-    taupairs = sorted([p for p in taupairs], key=lambda x: x[3], reverse = True)
 
     allobjects = {}
     for i,fj in enumerate(probejets):
@@ -189,7 +250,13 @@ def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, dotaus=Fals
     for i,j in enumerate(jetpairs):
       allobjects["JP_"+str(j[0]+1)+"_"+str(j[1]+1)] = j
     for i,t in enumerate(taupairs):
-      allobjects["TauP_"+str(t[0]+1)+"_"+str(t[1]+1)] = t
+      if t[6]==-15*15: FS = "_TauTau"
+      elif t[6]==-13*15: FS = "_MuTau"
+      elif t[6]==-11*15: FS = "_ElTau"
+      elif t[6]==-11*13: FS = "_ElMu"
+      elif t[6]==-13*13: FS = "_MuMu"
+      elif t[6]==-11*11: FS = "_ElEl"
+      allobjects["TauP_"+str(t[0]+1)+"_"+str(t[1]+1)+FS] = t
     objlist_jet = [k for k in allobjects if "J" in k]
     objlist_tau = [k for k in allobjects if "Tau" in k]
 
@@ -229,60 +296,102 @@ def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, dotaus=Fals
       j.append(dummyJet)
     TauIsBoosted = 0
     TauIsResolved = 0
-    if permutations==[]: return 0,0,h[0],h[1],h[2],j[0],j[1],j[2],j[3],j[4],j[5],TauIsBoosted,TauIsResolved
+    TauFinalState = 0
+    if permutations==[]: return 0,0,h[0],h[1],h[2],j[0],j[1],j[2],j[3],j[4],j[5],TauIsBoosted,TauIsResolved,TauFinalState
     nHiggs = len(permutations[0])
     assert all([nHiggs==len(perm) for perm in permutations])
     assert all([len([name for name in perm if "Tau" in name])<=1 for perm in permutations])
 
-    min_chi2 = 1000000000000000
-    for permutation in permutations:
-      masses = []
-      for name in permutation:
-        thismass = allobjects[name].mass if name.startswith("F") else allobjects[name][5]
-        masses.append(thismass)
-      fitted_mass = sum(masses)/nHiggs
-      chi2 = 0.0
-      for m in masses:
-        chi2 += (m - fitted_mass)**2
-      if chi2 < min_chi2:
-        m_fit = fitted_mass
-        min_chi2 = chi2
-        finalPermutation = permutation
-      if nHiggs==1: break # Use the jet pair with highest score, which will be always the first
+    if False: # Select the pair that results in masses being the most similar to each other
+      min_chi2 = 1000000000000000
+      #print("========")
+      #print(dotaus)
+      #if dotaus:
+      #  print("N_tau:",len(taus_4vec),"; N_lep:",len(leptons_4vec))
+      #print(permutations)
+      for permutation in permutations:
+        masses = []
+        for name in permutation:
+          thismass = allobjects[name].mass if name.startswith("F") else allobjects[name][5]
+          masses.append(thismass)
+        fitted_mass = sum(masses)/nHiggs
+        chi2 = 0.0
+        for m in masses:
+          chi2 += (m - fitted_mass)**2
+        if chi2 < min_chi2:
+          m_fit = fitted_mass
+          min_chi2 = chi2
+          finalPermutation = permutation
+        if nHiggs==1: break # Use the jet pair with highest score, which will be always the first
+    else: # Select pair such that resulting masses are close to Higgs boson mass
+      min_chi2 = 1000000000000000
+      for permutation in permutations:
+        masses = []
+        expmasses = []
+        for name in permutation:
+          # The reconstructed Higgs mass depends on its pT
+          if name.startswith("F"):
+            masses.append(allobjects[name].mass)
+            if "Tau" in name:
+              # Generally lower than Hbb FatJets because neutrino contribution is completely missing here
+              expmasses.append(-61.585812326376264 + 0.05557800375177941*pt + 160.86030949003612 * math.erf(0.00369513146940551*pt))
+            else:
+              expmasses.append(-351.51178268548455 - 0.0047614727864319405*pt + 483.2014163177754 * math.erf(0.005008209116766995*pt))
+          else:
+            masses.append(allobjects[name][5])
+            pt = allobjects[name][2].Pt()
+            expmasses.append(94.30387125781559 + 0.15218879725691964*pt - 0.00030092926621392484*pt*pt + 2.6331953438047053e-07*pt*pt*pt)
+        chi2 = 0.0
+        for m in range(len(masses)):
+          chi2 += (masses[m] - expmasses[m])**2
+        if chi2 < min_chi2:
+          m_fit = sum(expmasses)/nHiggs
+          min_chi2 = chi2
+          finalPermutation = permutation
+      
 
     nBoostedH = len([name for name in finalPermutation if name.startswith("F")])
     jetCandCount = 0
     for i in range(nHiggs):
       if finalPermutation[i].startswith("F"):
         h[i] = allobjects[finalPermutation[i]]
-        setattr(h[i], "matchH"+str(i+1), h[i].HiggsMatch)
+        h[i].matchH = h[i].HiggsMatchIndex if h[i].HiggsMatchIndex>=0 else 0
         if Run==2:
           h[i].Mass = h[i].particleNet_mass
         else:
           h[i].Mass = h[i].mass*h[i].particleNet_massCorr
         h[i].dRjets = -1
-        if "Tau" in finalPermutation[i]: TauIsBoosted = i+1
+        if "Tau" in finalPermutation[i]:
+          TauIsBoosted = i+1
+          if h[i].Xtautau > h[i].Xtaumu and h[i].Xtautau > h[i].Xtaue:
+            TauFinalState = -15*15
+          elif h[i].Xtaumu > h[i].Xtaue:
+            TauFinalState = -13*15
+          else:
+            TauFinalState = -11*15
       else:
         h[i] = allobjects[finalPermutation[i]][2]
         h[i].Mass = allobjects[finalPermutation[i]][5] # h[i].M()
         h[i].pt = h[i].Pt()
         h[i].eta = h[i].Eta()
         h[i].phi = h[i].Phi()
-        setattr(h[i], "matchH"+str(i+1), False)
+        h[i].matchH = 0
         if allobjects[finalPermutation[i]][4]=="Jet":
           j[jetCandCount] = jets_4vec[allobjects[finalPermutation[i]][0]]
           j[jetCandCount+1] = jets_4vec[allobjects[finalPermutation[i]][1]]
-          h[i].dRjets = deltaR(j[jetCandCount].eta(),j[jetCandCount].phi(),j[jetCandCount+1].eta(),j[jetCandCount+1].phi())
+          h[i].dRjets = deltaR(j[jetCandCount].Eta(),j[jetCandCount].Phi(),j[jetCandCount+1].Eta(),j[jetCandCount+1].Phi())
           if j[jetCandCount].HiggsMatch == True and j[jetCandCount+1].HiggsMatch == True and j[jetCandCount].HiggsMatchIndex == j[jetCandCount+1].HiggsMatchIndex:
-            setattr(h[i], "matchH"+str(i+1), True)
+            h[i].matchH = j[jetCandCount].HiggsMatchIndex
         elif allobjects[finalPermutation[i]][4]=="Tau":
-          j[jetCandCount] = taus_4vec[allobjects[finalPermutation[i]][0]]
-          j[jetCandCount+1] = taus_4vec[allobjects[finalPermutation[i]][1]]
-          h[i].dRjets = deltaR(j[jetCandCount].eta(),j[jetCandCount].phi(),j[jetCandCount+1].eta(),j[jetCandCount+1].phi())
+          j[jetCandCount] = taulepton_4vec[allobjects[finalPermutation[i]][0]]
+          j[jetCandCount+1] = taulepton_4vec[allobjects[finalPermutation[i]][1]]
+          h[i].dRjets = deltaR(j[jetCandCount].Eta(),j[jetCandCount].Phi(),j[jetCandCount+1].Eta(),j[jetCandCount+1].Phi())
           if j[jetCandCount].HiggsMatch == True and j[jetCandCount+1].HiggsMatch == True and j[jetCandCount].HiggsMatchIndex == j[jetCandCount+1].HiggsMatchIndex:
-            setattr(h[i], "matchH"+str(i+1), True)
+            h[i].matchH = j[jetCandCount].HiggsMatchIndex
         jetCandCount += 2
-        if "Tau" in finalPermutation[i]: TauIsResolved = i+1
+        if "Tau" in finalPermutation[i]:
+          TauIsResolved = i+1
+          TauFinalState = allobjects[finalPermutation[i]][6]
     if nHiggs==3:
       #if nBoostedH==3: recoidx = 1
       #elif nBoostedH==2: recoidx = 2
@@ -298,5 +407,5 @@ def higgsPairingAlgorithm_v2(event, jets, fatjets, XbbWP, isMC, Run, dotaus=Fals
       #if nBoostedH==1: recoidx = 8
       #elif nBoostedH==0: recoidx = 9
       recoidx = 9-nBoostedH
-    # return reco_idx, fitted_mass, Higgs 1/2/3, Jets 1/2/3/4/5/6, TauBoosted H Idx, TauResolved H Idx
-    return recoidx,m_fit,h[0],h[1],h[2],j[0],j[1],j[2],j[3],j[4],j[5],TauIsBoosted,TauIsResolved
+    # return reco_idx, fitted_mass, Higgs 1/2/3, Jets 1/2/3/4/5/6, TauBoosted H Idx, TauResolved H Idx, FinalState of Htautau
+    return recoidx,m_fit,h[0],h[1],h[2],j[0],j[1],j[2],j[3],j[4],j[5],TauIsBoosted,TauIsResolved,TauFinalState

--- a/python/producers/hhh6bProducerPNetAK4.py
+++ b/python/producers/hhh6bProducerPNetAK4.py
@@ -445,6 +445,14 @@ class hhh6bProducerPNetAK4(Module):
         self.out.branch("h1_4b2t_mass", "F")
         self.out.branch("h1_4b2t_match", "I")
         self.out.branch("h1_4b2t_dRjets", "F")
+        self.out.branch("h1_4b2t_FJ1idx", "I")
+        self.out.branch("h1_4b2t_FJ2idx", "I")
+        self.out.branch("h1_4b2t_J1idx", "I")
+        self.out.branch("h1_4b2t_J2idx", "I")
+        self.out.branch("h1_4b2t_T1idx", "I")
+        self.out.branch("h1_4b2t_T2idx", "I")
+        self.out.branch("h1_4b2t_L1idx", "I")
+        self.out.branch("h1_4b2t_L2idx", "I")
 
         self.out.branch("h2_4b2t_pt", "F")
         self.out.branch("h2_4b2t_eta", "F")
@@ -452,6 +460,14 @@ class hhh6bProducerPNetAK4(Module):
         self.out.branch("h2_4b2t_mass", "F")
         self.out.branch("h2_4b2t_match", "I")
         self.out.branch("h2_4b2t_dRjets", "F")
+        self.out.branch("h2_4b2t_FJ1idx", "I")
+        self.out.branch("h2_4b2t_FJ2idx", "I")
+        self.out.branch("h2_4b2t_J1idx", "I")
+        self.out.branch("h2_4b2t_J2idx", "I")
+        self.out.branch("h2_4b2t_T1idx", "I")
+        self.out.branch("h2_4b2t_T2idx", "I")
+        self.out.branch("h2_4b2t_L1idx", "I")
+        self.out.branch("h2_4b2t_L2idx", "I")
 
         self.out.branch("h3_4b2t_pt", "F")
         self.out.branch("h3_4b2t_eta", "F")
@@ -459,6 +475,14 @@ class hhh6bProducerPNetAK4(Module):
         self.out.branch("h3_4b2t_mass", "F")
         self.out.branch("h3_4b2t_match", "I")
         self.out.branch("h3_4b2t_dRjets", "F")
+        self.out.branch("h3_4b2t_FJ1idx", "I")
+        self.out.branch("h3_4b2t_FJ2idx", "I")
+        self.out.branch("h3_4b2t_J1idx", "I")
+        self.out.branch("h3_4b2t_J2idx", "I")
+        self.out.branch("h3_4b2t_T1idx", "I")
+        self.out.branch("h3_4b2t_T2idx", "I")
+        self.out.branch("h3_4b2t_L1idx", "I")
+        self.out.branch("h3_4b2t_L2idx", "I")
 
         self.out.branch("h_fit_mass_4b2t", "F")
 
@@ -930,8 +954,8 @@ class hhh6bProducerPNetAK4(Module):
         looseMuons = [l for l in event.looseLeptons if abs(l.Id)==13]
         looseElectrons = [l for l in event.looseLeptons if abs(l.Id)==11]
         for j in event.ak4jets:
-            j.hasMuon = True if (closest(j, looseMuons)[1] < 1.0) else False
-            j.hasElectron = True if (closest(j, looseElectrons)[1] < 1.0) else False
+            j.hasMuon = True if (closest(j, looseMuons)[1] < 0.5) else False
+            j.hasElectron = True if (closest(j, looseElectrons)[1] < 0.5) else False
         for j in event.fatjets:
             j.hasMuon = True if (closest(j, looseMuons)[1] < 1.0) else False
             j.hasElectron = True if (closest(j, looseElectrons)[1] < 1.0) else False
@@ -1482,6 +1506,14 @@ class hhh6bProducerPNetAK4(Module):
             self.out.fillBranch("h1_4b2t_phi", h1.phi)
             self.out.fillBranch("h1_4b2t_match", h1.matchH)
             self.out.fillBranch("h1_4b2t_dRjets", h1.dRjets)
+            self.out.fillBranch("h1_4b2t_FJ1idx", h1.FJ1idx)
+            self.out.fillBranch("h1_4b2t_FJ2idx", h1.FJ2idx)
+            self.out.fillBranch("h1_4b2t_J1idx", h1.J1idx)
+            self.out.fillBranch("h1_4b2t_J2idx", h1.J2idx)
+            self.out.fillBranch("h1_4b2t_T1idx", h1.T1idx)
+            self.out.fillBranch("h1_4b2t_T2idx", h1.T2idx)
+            self.out.fillBranch("h1_4b2t_L1idx", h1.L1idx)
+            self.out.fillBranch("h1_4b2t_L2idx", h1.L2idx)
 
             self.out.fillBranch("h2_4b2t_mass", h2.Mass)
             self.out.fillBranch("h2_4b2t_pt", h2.pt)
@@ -1489,6 +1521,14 @@ class hhh6bProducerPNetAK4(Module):
             self.out.fillBranch("h2_4b2t_phi", h2.phi)
             self.out.fillBranch("h2_4b2t_match", h2.matchH)
             self.out.fillBranch("h2_4b2t_dRjets", h2.dRjets)
+            self.out.fillBranch("h2_4b2t_FJ1idx", h1.FJ1idx)
+            self.out.fillBranch("h2_4b2t_FJ2idx", h1.FJ2idx)
+            self.out.fillBranch("h2_4b2t_J1idx", h1.J1idx)
+            self.out.fillBranch("h2_4b2t_J2idx", h1.J2idx)
+            self.out.fillBranch("h2_4b2t_T1idx", h1.T1idx)
+            self.out.fillBranch("h2_4b2t_T2idx", h1.T2idx)
+            self.out.fillBranch("h2_4b2t_L1idx", h1.L1idx)
+            self.out.fillBranch("h2_4b2t_L2idx", h1.L2idx)
 
             self.out.fillBranch("h3_4b2t_mass", h3.Mass)
             self.out.fillBranch("h3_4b2t_pt", h3.pt)
@@ -1496,6 +1536,14 @@ class hhh6bProducerPNetAK4(Module):
             self.out.fillBranch("h3_4b2t_phi", h3.phi)
             self.out.fillBranch("h3_4b2t_match", h3.matchH)
             self.out.fillBranch("h3_4b2t_dRjets", h3.dRjets)
+            self.out.fillBranch("h3_4b2t_FJ1idx", h1.FJ1idx)
+            self.out.fillBranch("h3_4b2t_FJ2idx", h1.FJ2idx)
+            self.out.fillBranch("h3_4b2t_J1idx", h1.J1idx)
+            self.out.fillBranch("h3_4b2t_J2idx", h1.J2idx)
+            self.out.fillBranch("h3_4b2t_T1idx", h1.T1idx)
+            self.out.fillBranch("h3_4b2t_T2idx", h1.T2idx)
+            self.out.fillBranch("h3_4b2t_L1idx", h1.L1idx)
+            self.out.fillBranch("h3_4b2t_L2idx", h1.L2idx)
 
             self.out.fillBranch("max_h_eta_4b2t", max(abs(h1.eta), abs(h2.eta), abs(h3.eta)))
             self.out.fillBranch("min_h_eta_4b2t", min(abs(h1.eta), abs(h2.eta), abs(h3.eta)))
@@ -2542,6 +2590,7 @@ class hhh6bProducerPNetAK4(Module):
         elif self._opts['option'] == "4":
             #if (self.nSmallJets > 5 and self.nBTaggedJets > 2): passSel = True
             if (self.nSmallJets > -1): passSel = True
+            #if len(event.ak4jets)==0 and len(probe_jets)==0 len(event.looseTaus)==0 and len(event.looseLeptons)==0: passSel = False
 
         if not passSel: return False
 
@@ -2580,7 +2629,7 @@ class hhh6bProducerPNetAK4(Module):
                             matched += 1
                             matchedthishiggs.append(j)
                             matchedthisdau.append(dau)
-                # Get the invariant mass of gen-matched objects, fot both Hbb and Htautau
+                # Get the invariant mass of gen-matched objects, for both Hbb and Htautau
                 if len(matchedthishiggs)==2 and matchedthisdau[0]!=matchedthisdau[1] and deltaR(matchedthishiggs[0],matchedthishiggs[1])>0.5:
                     combgen = polarP4(matchedthishiggs[0])+polarP4(matchedthishiggs[1])
                     dau1pdgid = daughters[-2].pdgId

--- a/python/producers/hhh6bProducerPNetAK4.py
+++ b/python/producers/hhh6bProducerPNetAK4.py
@@ -2,6 +2,7 @@ import os
 import itertools
 import ROOT
 import random
+import math
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 import numpy as np
 from collections import Counter
@@ -359,7 +360,6 @@ class hhh6bProducerPNetAK4(Module):
 
             prefix = 'fatJet%i' % idx
             self.out.branch(prefix + "Pt", "F")
-            self.out.branch(prefix + "MatchedGenPt", "F")
             self.out.branch(prefix + "Eta", "F")
             self.out.branch(prefix + "Phi", "F")
             self.out.branch(prefix + "RawFactor", "F")
@@ -376,6 +376,8 @@ class hhh6bProducerPNetAK4(Module):
                 self.out.branch(prefix + "PNetXtauany", "F")
             self.out.branch(prefix + "PNetQCD", "F")
             self.out.branch(prefix + "Area", "F")
+            self.out.branch(prefix + "n3b1", "F")
+            self.out.branch(prefix + "Tau2OverTau1", "F")
             self.out.branch(prefix + "Tau3OverTau2", "F")
             self.out.branch(prefix + "GenMatchIndex", "I")
             self.out.branch(prefix + "HiggsMatchedIndex", "I")
@@ -393,8 +395,10 @@ class hhh6bProducerPNetAK4(Module):
             self.out.branch(prefix + "PtOverMSD", "F")
             self.out.branch(prefix + "PtOverMRegressed", "F")
 
-            # uncertainties
             if self.isMC:
+                self.out.branch(prefix + "MatchedGenPt", "F")
+
+                # uncertainties
                 self.out.branch(prefix + "MassSD_JMS_Down", "F")
                 self.out.branch(prefix + "MassSD_JMS_Up", "F")
                 self.out.branch(prefix + "MassSD_JMR_Down", "F")
@@ -416,21 +420,21 @@ class hhh6bProducerPNetAK4(Module):
         self.out.branch("h1_t3_eta", "F")
         self.out.branch("h1_t3_phi", "F")
         self.out.branch("h1_t3_mass", "F")
-        self.out.branch("h1_t3_match", "O")
+        self.out.branch("h1_t3_match", "I")
         self.out.branch("h1_t3_dRjets", "F")
 
         self.out.branch("h2_t3_pt", "F")
         self.out.branch("h2_t3_eta", "F")
         self.out.branch("h2_t3_phi", "F")
         self.out.branch("h2_t3_mass", "F")
-        self.out.branch("h2_t3_match", "O")
+        self.out.branch("h2_t3_match", "I")
         self.out.branch("h2_t3_dRjets", "F")
 
         self.out.branch("h3_t3_pt", "F")
         self.out.branch("h3_t3_eta", "F")
         self.out.branch("h3_t3_phi", "F")
         self.out.branch("h3_t3_mass", "F")
-        self.out.branch("h3_t3_match", "O")
+        self.out.branch("h3_t3_match", "I")
         self.out.branch("h3_t3_dRjets", "F")
 
         self.out.branch("h_fit_mass", "F")
@@ -439,21 +443,21 @@ class hhh6bProducerPNetAK4(Module):
         self.out.branch("h1_4b2t_eta", "F")
         self.out.branch("h1_4b2t_phi", "F")
         self.out.branch("h1_4b2t_mass", "F")
-        self.out.branch("h1_4b2t_match", "O")
+        self.out.branch("h1_4b2t_match", "I")
         self.out.branch("h1_4b2t_dRjets", "F")
 
         self.out.branch("h2_4b2t_pt", "F")
         self.out.branch("h2_4b2t_eta", "F")
         self.out.branch("h2_4b2t_phi", "F")
         self.out.branch("h2_4b2t_mass", "F")
-        self.out.branch("h2_4b2t_match", "O")
+        self.out.branch("h2_4b2t_match", "I")
         self.out.branch("h2_4b2t_dRjets", "F")
 
         self.out.branch("h3_4b2t_pt", "F")
         self.out.branch("h3_4b2t_eta", "F")
         self.out.branch("h3_4b2t_phi", "F")
         self.out.branch("h3_4b2t_mass", "F")
-        self.out.branch("h3_4b2t_match", "O")
+        self.out.branch("h3_4b2t_match", "I")
         self.out.branch("h3_4b2t_dRjets", "F")
 
         self.out.branch("h_fit_mass_4b2t", "F")
@@ -462,6 +466,7 @@ class hhh6bProducerPNetAK4(Module):
         self.out.branch("reco4b2t_Idx", "I")
         self.out.branch("reco4b2t_TauIsBoosted", "I")
         self.out.branch("reco4b2t_TauIsResolved", "I")
+        self.out.branch("reco4b2t_TauFinalState", "I")
 
         # max min
         self.out.branch("max_h_eta", "F")
@@ -491,7 +496,6 @@ class hhh6bProducerPNetAK4(Module):
             self.out.branch(prefix + "PNetB", "F")
             self.out.branch(prefix + "Mass", "F")
             self.out.branch(prefix + "RawFactor", "F")
-            self.out.branch(prefix + "MatchedGenPt", "F")
             self.out.branch(prefix + "Area", "F")
 
             self.out.branch(prefix + "HasMuon", "O")
@@ -504,6 +508,7 @@ class hhh6bProducerPNetAK4(Module):
                 self.out.branch(prefix + "cRegCorr", "F")
                 self.out.branch(prefix + "cRegRes", "F")
             if self.isMC:
+                self.out.branch(prefix + "MatchedGenPt", "F")
                 self.out.branch(prefix + "HadronFlavour", "F")
                 self.out.branch(prefix + "HiggsMatched", "O")
                 self.out.branch(prefix + "HiggsMatchedIndex", "I")
@@ -511,12 +516,20 @@ class hhh6bProducerPNetAK4(Module):
                 self.out.branch(prefix + "FatJetMatchedIndex", "I")
 
         # leptons
-        for idx in ([1, 2]):
+        for idx in ([1, 2, 3, 4]):
             prefix = 'lep%i'%idx
+            self.out.branch(prefix + "Charge", "F")
             self.out.branch(prefix + "Pt", "F")
             self.out.branch(prefix + "Eta", "F")
             self.out.branch(prefix + "Phi", "F")
+            self.out.branch(prefix + "Mass", "F")
             self.out.branch(prefix + "Id", "I")
+            if self.isMC:
+                self.out.branch(prefix + "MatchedGenPt", "F")
+                self.out.branch(prefix + "HiggsMatched", "O")
+                self.out.branch(prefix + "HiggsMatchedIndex", "I")
+                self.out.branch(prefix + "FatJetMatched", "O")
+                self.out.branch(prefix + "FatJetMatchedIndex", "I")
 
         for idx in ([1, 2, 3, 4]):
             prefix = 'tau%i'%idx
@@ -527,7 +540,6 @@ class hhh6bProducerPNetAK4(Module):
             self.out.branch(prefix + "Mass", "F")
             self.out.branch(prefix + "Id", "I")
             self.out.branch(prefix + "decayMode", "F")
-            self.out.branch(prefix + "MatchedGenPt", "F")
 
             if self.Run==2: # TODO: Can switch to v2p5 for Run2UL too, if inputs have branches available
                 self.out.branch(prefix + "rawDeepTau2017v2p1VSe", "F")
@@ -538,6 +550,7 @@ class hhh6bProducerPNetAK4(Module):
                 self.out.branch(prefix + "rawDeepTau2018v2p5VSjet", "F")
                 self.out.branch(prefix + "rawDeepTau2018v2p5VSmu", "F")
             if self.isMC:
+                self.out.branch(prefix + "MatchedGenPt", "F")
                 self.out.branch(prefix + "HiggsMatched", "O")
                 self.out.branch(prefix + "HiggsMatchedIndex", "I")
                 self.out.branch(prefix + "FatJetMatched", "O")
@@ -550,6 +563,16 @@ class hhh6bProducerPNetAK4(Module):
             self.out.branch(prefix + "Eta", "F")
             self.out.branch(prefix + "Phi", "F")
             self.out.branch(prefix + "Decay", "I")
+            self.out.branch(prefix + "RecoPt", "F")
+            self.out.branch(prefix + "RecoEta", "F")
+            self.out.branch(prefix + "RecoPhi", "F")
+            self.out.branch(prefix + "RecoMass", "F")
+        for idx in ([1, 2, 3, 4, 5, 6]):
+            prefix = 'genHiggsDau%i'%idx
+            self.out.branch(prefix + "Pt", "F")
+            self.out.branch(prefix + "Eta", "F")
+            self.out.branch(prefix + "Phi", "F")
+            self.out.branch(prefix + "Id", "I")
 
     def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         if self._opts['run_mass_regression'] and self._opts['WRITE_CACHE_FILE']:
@@ -680,6 +703,8 @@ class hhh6bProducerPNetAK4(Module):
         electrons = Collection(event, "Electron")
         for el in electrons:
             el.Id = el.charge * (-11)
+            el.kind = self.kTauToElecDecay
+            el.mass = 0.000511
             #if el.pt > 35 and abs(el.eta) <= 2.5 and el.miniPFRelIso_all <= 0.2 and el.cutBased:
             if self.Run==2:
                 if el.pt > 10 and abs(el.eta) <= 2.5 and abs(el.dxy) < 0.045 and abs(el.dz) < 0.2 and el.miniPFRelIso_all <= 0.2 and el.lostHits <= 1 and el.convVeto and el.mvaFall17V2noIso_WP90: #and el.cutBased>3: # cutBased ID: (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)
@@ -697,6 +722,8 @@ class hhh6bProducerPNetAK4(Module):
         muons = Collection(event, "Muon")
         for mu in muons:
             mu.Id = mu.charge * (-13)
+            mu.kind = self.kTauToMuDecay
+            mu.mass = 0.10566
             if mu.pt > 10 and abs(mu.eta) <= 2.4 and abs(mu.dxy) < 0.045 and abs(mu.dz) < 0.2 and mu.mediumId and mu.miniPFRelIso_all <= 0.2: # mu.tightId
                 event.looseLeptons.append(mu)
             if mu.pt > 30 and mu.looseId:
@@ -708,11 +735,11 @@ class hhh6bProducerPNetAK4(Module):
             tau.kind = self.kTauToHadDecay
             if tau.decayMode==0: tau.mass = 0.13957
             if self.Run==2:
-                if tau.pt > 20 and abs(tau.eta) <= 2.3 and abs(tau.dz) < 0.2 and (tau.decayMode in [0,1,2,10,11]) and tau.idDeepTau2017v2p1VSe >= 2 and tau.idDeepTau2017v2p1VSmu >= 1 and tau.idDeepTau2017v2p1VSjet >= 8:
-                    event.looseTaus.append(tau) # VVloose VsE, VLoose vsMu, Loose Vsjet
+                if tau.pt > 20 and abs(tau.eta) <= 2.3 and abs(tau.dz) < 0.2 and (tau.decayMode in [0,1,2,10,11]) and tau.idDeepTau2017v2p1VSe >= 1 and tau.idDeepTau2017v2p1VSmu >= 1 and tau.idDeepTau2017v2p1VSjet >= 1:
+                    event.looseTaus.append(tau) # All loosest WPs. To use later: VVloose VsE (2), VLoose vsMu (1), Loose Vsjet (8)
             else:
-                if tau.pt > 20 and abs(tau.eta) <= 2.5 and abs(tau.dz) < 0.2 and (tau.decayMode in [0,1,2,10,11]) and tau.idDeepTau2018v2p5VSe >= 2 and tau.idDeepTau2018v2p5VSmu >= 1 and tau.idDeepTau2018v2p5VSjet >= 4:
-                    event.looseTaus.append(tau) # VVloose VsE, VLoose vsMu, Loose Vsjet
+                if tau.pt > 20 and abs(tau.eta) <= 2.5 and abs(tau.dz) < 0.2 and (tau.decayMode in [0,1,2,10,11]) and tau.idDeepTau2018v2p5VSe >= 1 and tau.idDeepTau2018v2p5VSmu >= 1 and tau.idDeepTau2018v2p5VSjet >= 1:
+                    event.looseTaus.append(tau) # All loosest WPs. To use later: VVloose VsE (2), VLoose vsMu (1), Loose Vsjet (4)
 
         event.looseLeptons.sort(key=lambda x: x.pt, reverse=True)
         if self.Run==2:
@@ -799,6 +826,7 @@ class hhh6bProducerPNetAK4(Module):
                         else:
                             fj.Xjj = -1
                         fj.t32 = (fj.tau3/fj.tau2) if fj.tau2 > 0 else -1
+                        fj.t21 = (fj.tau2/fj.tau1) if fj.tau1 > 0 else -1
                         fj.msoftdropJMS = fj.msoftdrop*self._jmsValues[0]
 
             for key,corr in self.jetmetCorrectors.items():
@@ -867,6 +895,7 @@ class hhh6bProducerPNetAK4(Module):
             else:
                 fj.Xjj = -1
             fj.t32 = (fj.tau3/fj.tau2) if fj.tau2 > 0 else -1
+            fj.t21 = (fj.tau2/fj.tau1) if fj.tau1 > 0 else -1
             if self.isMC:
                 fj.msoftdropJMS = fj.msoftdrop*self._jmsValues[0]
             else:
@@ -898,14 +927,13 @@ class hhh6bProducerPNetAK4(Module):
             ak4jets_unclean = [j for j in event._allJets if j.pt > 20 and abs(j.eta) < 2.5 and j.jetId >= 6 and ((j.puId == puid or j.puId == 7) or j.pt > 50)]
         else:
             # No puid in Run3, because "default" jets are PuppiJets
-            AK4PNetBWP = {"2022": {"L": 0.047, "M": 0.245, "T": 0.6734, "XT": 0.7862, "XXT": 0.961}, "2022EE": {"L": 0.0499, "M": 0.2605, "T": 0.6915, "XT": 0.8033, "XXT": 0.9664}, "2023": {"L": 0.0358, "M": 0.1917, "T": 0.6172, "XT": 0.7515, "XXT": 0.9659}, "2023BPix": {"L": 0.0359, "M": 0.1919, "T": 0.6133, "XT": 0.7544, "XXT": 0.9688}}
-            ak4jets_unclean = [j for j in event._allJets if j.pt > 20 and abs(j.eta) < 2.5 and j.jetId >= 6 and j.btagPNetB > AK4PNetBWP[self.year]["T"]]
+            ak4jets_unclean = [j for j in event._allJets if j.pt > 20 and abs(j.eta) < 2.5 and j.jetId >= 2]
         # Clean Jets from Taus and Leptons
         event.ak4jets = []
         for j in ak4jets_unclean:
             goodjet = True
-            for l in event.looseLeptons+event.looseTaus:
-                if j.DeltaR(l) < 0.5:
+            for l in event.looseLeptons: # +event.looseTaus # Don't clean with Taus yet, when Taus have only very loostest WPs applied -> Might be genuine Jets
+                if j.DeltaR(l) < 0.4:
                     goodjet = False
                     break
             if goodjet: event.ak4jets.append(j)
@@ -1123,17 +1151,41 @@ class hhh6bProducerPNetAK4(Module):
                 self.out.fillBranch("genHiggs1Eta", hadGenHs[0].eta)
                 self.out.fillBranch("genHiggs1Phi", hadGenHs[0].phi)
                 self.out.fillBranch("genHiggs1Decay", HDecayMode(hadGenHs[0]))
+                self.out.fillBranch("genHiggsDau1Pt", event.genparts[hadGenHs[0].dauIdx[0]].pt)
+                self.out.fillBranch("genHiggsDau1Eta", event.genparts[hadGenHs[0].dauIdx[0]].eta)
+                self.out.fillBranch("genHiggsDau1Phi", event.genparts[hadGenHs[0].dauIdx[0]].phi)
+                self.out.fillBranch("genHiggsDau1Id", event.genparts[hadGenHs[0].dauIdx[0]].pdgId)
+                self.out.fillBranch("genHiggsDau2Pt", event.genparts[hadGenHs[0].dauIdx[1]].pt)
+                self.out.fillBranch("genHiggsDau2Eta", event.genparts[hadGenHs[0].dauIdx[1]].eta)
+                self.out.fillBranch("genHiggsDau2Phi", event.genparts[hadGenHs[0].dauIdx[1]].phi)
+                self.out.fillBranch("genHiggsDau2Id", event.genparts[hadGenHs[0].dauIdx[1]].pdgId)
                 if len(hadGenHs)>1:
                     self.out.fillBranch("genHiggs2Pt", hadGenHs[1].pt)
                     self.out.fillBranch("genHiggs2Eta", hadGenHs[1].eta)
                     self.out.fillBranch("genHiggs2Phi", hadGenHs[1].phi)
                     self.out.fillBranch("genHiggs2Decay", HDecayMode(hadGenHs[1]))
+                    self.out.fillBranch("genHiggsDau3Pt", event.genparts[hadGenHs[1].dauIdx[0]].pt)
+                    self.out.fillBranch("genHiggsDau3Eta", event.genparts[hadGenHs[1].dauIdx[0]].eta)
+                    self.out.fillBranch("genHiggsDau3Phi", event.genparts[hadGenHs[1].dauIdx[0]].phi)
+                    self.out.fillBranch("genHiggsDau3Id", event.genparts[hadGenHs[1].dauIdx[0]].pdgId)
+                    self.out.fillBranch("genHiggsDau4Pt", event.genparts[hadGenHs[1].dauIdx[1]].pt)
+                    self.out.fillBranch("genHiggsDau4Eta", event.genparts[hadGenHs[1].dauIdx[1]].eta)
+                    self.out.fillBranch("genHiggsDau4Phi", event.genparts[hadGenHs[1].dauIdx[1]].phi)
+                    self.out.fillBranch("genHiggsDau4Id", event.genparts[hadGenHs[1].dauIdx[1]].pdgId)
 
                     if len(hadGenHs)>2:
                         self.out.fillBranch("genHiggs3Pt", hadGenHs[2].pt)
                         self.out.fillBranch("genHiggs3Eta", hadGenHs[2].eta)
                         self.out.fillBranch("genHiggs3Phi", hadGenHs[2].phi)
                         self.out.fillBranch("genHiggs3Decay", HDecayMode(hadGenHs[2]))
+                        self.out.fillBranch("genHiggsDau5Pt", event.genparts[hadGenHs[2].dauIdx[0]].pt)
+                        self.out.fillBranch("genHiggsDau5Eta", event.genparts[hadGenHs[2].dauIdx[0]].eta)
+                        self.out.fillBranch("genHiggsDau5Phi", event.genparts[hadGenHs[2].dauIdx[0]].phi)
+                        self.out.fillBranch("genHiggsDau5Id", event.genparts[hadGenHs[2].dauIdx[0]].pdgId)
+                        self.out.fillBranch("genHiggsDau6Pt", event.genparts[hadGenHs[2].dauIdx[1]].pt)
+                        self.out.fillBranch("genHiggsDau6Eta", event.genparts[hadGenHs[2].dauIdx[1]].eta)
+                        self.out.fillBranch("genHiggsDau6Phi", event.genparts[hadGenHs[2].dauIdx[1]].phi)
+                        self.out.fillBranch("genHiggsDau6Id", event.genparts[hadGenHs[2].dauIdx[1]].pdgId)
 
     def _get_filler(self, obj):
         def filler(branch, value, default=0):
@@ -1221,6 +1273,8 @@ class hhh6bProducerPNetAK4(Module):
                 fill_fj(prefix + "HiggsMatchedIndex", fj.HiggsMatchIndex)
                 fill_fj(prefix + "MatchedGenPt", fj.MatchedGenPt)
 
+            fill_fj(prefix + "n3b1", fj.n3b1)
+            fill_fj(prefix + "Tau2OverTau1", fj.t21)
             fill_fj(prefix + "Tau3OverTau2", fj.t32)
             
             # uncertainties
@@ -1327,7 +1381,7 @@ class hhh6bProducerPNetAK4(Module):
                     fill_fj(prefix + "Pt" + "_" + syst, fj.pt)
                     fill_fj(prefix + "PtOverMHH" + "_" + syst, fj.pt/(h1Jet+h2Jet).M())
 
-    def fillJetInfo(self, event, jets, fatjets, XbbWP, taus, XtautauWP):
+    def fillJetInfo(self, event, jets, fatjets, XbbWP, taus, XtautauWP, leptons):
         self.out.fillBranch("nbtags", self.nBTaggedJets)
         self.out.fillBranch("nsmalljets",self.nSmallJets)
         self.out.fillBranch("ntaus",self.nTaus)
@@ -1379,33 +1433,49 @@ class hhh6bProducerPNetAK4(Module):
         event.reco4b2t_Idx = -1
         event.reco4b2t_TauIsBoosted = 0
         event.reco4b2t_TauIsResolved = 0
+        event.reco4b2t_TauFinalState = 0
 
         #if len(jets)+2*len(fatjets) > 5:
         if True:
             # Technique 3: mass fitter
             
             #m_fit,h1,h2,h3,j0,j1,j2,j3,j4,j5 = self.higgsPairingAlgorithm(event,jets,fatjets,XbbWP)
-            event.reco6b_Idx,m_fit,h1,h2,h3,j0,j1,j2,j3,j4,j5,bla1,bla2 = higgsPairingAlgorithm_v2(event,jets,fatjets,XbbWP,self.isMC,self.Run)
+            AK4PNetBWP = {"2022": {"L": 0.047, "M": 0.245, "T": 0.6734, "XT": 0.7862, "XXT": 0.961}, "2022EE": {"L": 0.0499, "M": 0.2605, "T": 0.6915, "XT": 0.8033, "XXT": 0.9664}, "2023": {"L": 0.0358, "M": 0.1917, "T": 0.6172, "XT": 0.7515, "XXT": 0.9659}, "2023BPix": {"L": 0.0359, "M": 0.1919, "T": 0.6133, "XT": 0.7544, "XXT": 0.9688}}
+            if self.year in AK4PNetBWP:
+                jetWP = AK4PNetBWP[self.year]["T"]
+                jetdiscr="btagPNetB"
+            else:
+                jetWP = 0.0
+                jetdiscr=""
+            if self.Run==2:
+                TauVsEl=2
+                TauVsMu=1
+                TauVsJet=8
+            else:
+                TauVsEl=2
+                TauVsMu=1
+                TauVsJet=4
+            event.reco6b_Idx,m_fit,h1,h2,h3,j0,j1,j2,j3,j4,j5,bla1,bla2,bla3 = higgsPairingAlgorithm_v2(event,jets,fatjets,XbbWP,self.isMC,self.Run,jetdicsr=jetdiscr,jetWP=jetWP,taus=taus,TauVsEl=TauVsEl,TauVsMu=TauVsMu,TauVsJet=TauVsJet,XtautauWP=XtautauWP)
                        
             self.out.fillBranch("h1_t3_mass", h1.Mass)
             self.out.fillBranch("h1_t3_pt", h1.pt)
-            self.out.fillBranch("h1_t3_eta", abs(h1.eta))
+            self.out.fillBranch("h1_t3_eta", h1.eta)
             self.out.fillBranch("h1_t3_phi", h1.phi)
-            self.out.fillBranch("h1_t3_match", h1.matchH1)
+            self.out.fillBranch("h1_t3_match", h1.matchH)
             self.out.fillBranch("h1_t3_dRjets", h1.dRjets)
 
             self.out.fillBranch("h2_t3_mass", h2.Mass)
             self.out.fillBranch("h2_t3_pt", h2.pt)
-            self.out.fillBranch("h2_t3_eta", abs(h2.eta))
+            self.out.fillBranch("h2_t3_eta", h2.eta)
             self.out.fillBranch("h2_t3_phi", h2.phi)
-            self.out.fillBranch("h2_t3_match", h2.matchH2)
+            self.out.fillBranch("h2_t3_match", h2.matchH)
             self.out.fillBranch("h2_t3_dRjets", h2.dRjets)
 
             self.out.fillBranch("h3_t3_mass", h3.Mass)
             self.out.fillBranch("h3_t3_pt", h3.pt)
-            self.out.fillBranch("h3_t3_eta", abs(h3.eta))
+            self.out.fillBranch("h3_t3_eta", h3.eta)
             self.out.fillBranch("h3_t3_phi", h3.phi)
-            self.out.fillBranch("h3_t3_match", h3.matchH3)
+            self.out.fillBranch("h3_t3_match", h3.matchH)
             self.out.fillBranch("h3_t3_dRjets", h3.dRjets)
 
             self.out.fillBranch("max_h_eta", max(abs(h1.eta), abs(h2.eta), abs(h3.eta)))
@@ -1419,27 +1489,27 @@ class hhh6bProducerPNetAK4(Module):
             # Technique 3: mass fitter for Taus
             
             #m_fit,h1,h2,h3,j0,j1,j2,j3,j4,j5 = self.higgsPairingAlgorithm(event,jets,fatjets,XbbWP,dotaus=True,taus=taus,XtautauWP=XtautauWP)
-            event.reco4b2t_Idx,m_fit,h1,h2,h3,j0,j1,j2,j3,j4,j5,event.reco4b2t_TauIsBoosted,event.reco4b2t_TauIsResolved = higgsPairingAlgorithm_v2(event,jets,fatjets,XbbWP,self.isMC,self.Run,dotaus=True,taus=taus,XtautauWP=XtautauWP,METvars=[event.PuppiMET_pt, event.PuppiMET_phi, event.MET_covXX, event.MET_covXY, event.MET_covYY])
+            event.reco4b2t_Idx,m_fit,h1,h2,h3,j0,j1,j2,j3,j4,j5,event.reco4b2t_TauIsBoosted,event.reco4b2t_TauIsResolved,event.reco4b2t_TauFinalState = higgsPairingAlgorithm_v2(event,jets,fatjets,XbbWP,self.isMC,self.Run,jetdicsr=jetdiscr,jetWP=jetWP,dotaus=True,taus=taus,TauVsEl=TauVsEl,TauVsMu=TauVsMu,TauVsJet=TauVsJet,XtautauWP=XtautauWP,leptons=leptons,METvars=[event.PuppiMET_pt, event.PuppiMET_phi, event.MET_covXX, event.MET_covXY, event.MET_covYY])
                        
             self.out.fillBranch("h1_4b2t_mass", h1.Mass)
             self.out.fillBranch("h1_4b2t_pt", h1.pt)
-            self.out.fillBranch("h1_4b2t_eta", abs(h1.eta))
+            self.out.fillBranch("h1_4b2t_eta", h1.eta)
             self.out.fillBranch("h1_4b2t_phi", h1.phi)
-            self.out.fillBranch("h1_4b2t_match", h1.matchH1)
+            self.out.fillBranch("h1_4b2t_match", h1.matchH)
             self.out.fillBranch("h1_4b2t_dRjets", h1.dRjets)
 
             self.out.fillBranch("h2_4b2t_mass", h2.Mass)
             self.out.fillBranch("h2_4b2t_pt", h2.pt)
-            self.out.fillBranch("h2_4b2t_eta", abs(h2.eta))
+            self.out.fillBranch("h2_4b2t_eta", h2.eta)
             self.out.fillBranch("h2_4b2t_phi", h2.phi)
-            self.out.fillBranch("h2_4b2t_match", h2.matchH2)
+            self.out.fillBranch("h2_4b2t_match", h2.matchH)
             self.out.fillBranch("h2_4b2t_dRjets", h2.dRjets)
 
             self.out.fillBranch("h3_4b2t_mass", h3.Mass)
             self.out.fillBranch("h3_4b2t_pt", h3.pt)
-            self.out.fillBranch("h3_4b2t_eta", abs(h3.eta))
+            self.out.fillBranch("h3_4b2t_eta", h3.eta)
             self.out.fillBranch("h3_4b2t_phi", h3.phi)
-            self.out.fillBranch("h3_4b2t_match", h3.matchH3)
+            self.out.fillBranch("h3_4b2t_match", h3.matchH)
             self.out.fillBranch("h3_4b2t_dRjets", h3.dRjets)
 
             self.out.fillBranch("max_h_eta_4b2t", max(abs(h1.eta), abs(h2.eta), abs(h3.eta)))
@@ -1449,22 +1519,30 @@ class hhh6bProducerPNetAK4(Module):
 
             self.out.fillBranch("h_fit_mass_4b2t", m_fit)
 
-        self.out.fillBranch("h3_4b2t_phi", -1)
         self.out.fillBranch("reco6b_Idx", event.reco6b_Idx)
         self.out.fillBranch("reco4b2t_Idx", event.reco4b2t_Idx)
         self.out.fillBranch("reco4b2t_TauIsBoosted", event.reco4b2t_TauIsBoosted)
         self.out.fillBranch("reco4b2t_TauIsResolved", event.reco4b2t_TauIsResolved)
+        self.out.fillBranch("reco4b2t_TauFinalState", event.reco4b2t_TauFinalState)
 
             
     def fillLeptonInfo(self, event, leptons):
-        for idx in ([1, 2]):
+        for idx in ([1, 2, 3, 4]):
             lep = leptons[idx-1]if len(leptons)>idx-1 else _NullObject()
             prefix = 'lep%i'%(idx)
             fillBranch = self._get_filler(lep)
+            fillBranch(prefix + "Charge", lep.charge)
             fillBranch(prefix + "Pt", lep.pt)
             fillBranch(prefix + "Eta", lep.eta)
             fillBranch(prefix + "Phi", lep.phi)
+            fillBranch(prefix + "Mass", lep.mass)
             fillBranch(prefix + "Id", lep.Id)
+            if self.isMC:
+                fillBranch(prefix + "HiggsMatched", lep.HiggsMatch)
+                fillBranch(prefix + "HiggsMatchedIndex", lep.HiggsMatchIndex)
+                fillBranch(prefix + "FatJetMatched", lep.FatJetMatch)
+                fillBranch(prefix + "FatJetMatchedIndex", lep.FatJetMatchIndex)
+                fillBranch(prefix + "MatchedGenPt", lep.MatchedGenPt)
     def fillTauInfo(self, event, leptons):
         for idx in ([1, 2, 3, 4]):
             lep = leptons[idx-1] if len(leptons)>idx-1 else _NullObject()
@@ -2486,7 +2564,7 @@ class hhh6bProducerPNetAK4(Module):
         hadGenHs = self.loadGenHistory(event, probe_jets)
         self.hadGenHs = hadGenHs
 
-        for j in event.ak4jets+event.looseTaus:
+        for j in event.ak4jets+event.looseTaus+event.looseLeptons:
             j.HiggsMatch = False
             j.FatJetMatch = False
             j.HiggsMatchIndex = -1
@@ -2502,15 +2580,67 @@ class hhh6bProducerPNetAK4(Module):
             daughters = []
             matched = 0
             for index_h, higgs_gen in enumerate(hadGenHs):
+                matchedthishiggs = []
+                matchedthisdau = []
                 for idx in higgs_gen.dauIdx:
                     dau = event.genparts[idx]
                     daughters.append(dau)
-                    for j in event.ak4jets+event.looseTaus:
+                    for j in event.ak4jets+event.looseTaus+event.looseLeptons:
+                        if j in event.ak4jets and abs(dau.pdgId)!=5: continue
+                        if j in event.looseTaus+event.looseLeptons and abs(dau.pdgId)==5: continue
                         if deltaR(j,dau) < 0.4:
                             j.HiggsMatch = True
                             j.HiggsMatchIndex = index_h+1
                             j.MatchedGenPt = dau.pt
                             matched += 1
+                            matchedthishiggs.append(j)
+                            matchedthisdau.append(dau)
+                # Get the invariant mass of gen-matched objects, fot both Hbb and Htautau
+                if len(matchedthishiggs)==2 and matchedthisdau[0]!=matchedthisdau[1] and deltaR(matchedthishiggs[0],matchedthishiggs[1])>0.4:
+                    combgen = polarP4(matchedthishiggs[0])+polarP4(matchedthishiggs[1])
+                    dau1pdgid = daughters[-2].pdgId
+                    dau2pdgid = daughters[-1].pdgId
+                    if dau1pdgid*dau2pdgid == -5*5 and matchedthishiggs[0] in event.ak4jets and matchedthishiggs[1] in event.ak4jets:
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoPt", combgen.Pt())
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoEta", combgen.Eta())
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoPhi", combgen.Phi())
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoMass", combgen.M())
+                    elif dau1pdgid*dau2pdgid != -5*5 and (matchedthishiggs[0] not in event.ak4jets) and (matchedthishiggs[1] not in event.ak4jets): # FastMTT for HTauTau
+                        dm1 = matchedthishiggs[0].decayMode if matchedthishiggs[0] in event.looseTaus else -1
+                        tau1 = ROOT.MeasuredTauLepton(matchedthishiggs[0].kind, matchedthishiggs[0].pt, matchedthishiggs[0].eta, matchedthishiggs[0].phi, matchedthishiggs[0].mass, dm1)
+                        dm2 = matchedthishiggs[1].decayMode if matchedthishiggs[1] in event.looseTaus else -1
+                        tau2 = ROOT.MeasuredTauLepton(matchedthishiggs[1].kind, matchedthishiggs[1].pt, matchedthishiggs[1].eta, matchedthishiggs[1].phi, matchedthishiggs[1].mass, dm2)
+                        VectorOfTaus = ROOT.std.vector('MeasuredTauLepton')
+                        bothtaus = VectorOfTaus()
+                        bothtaus.push_back(tau1)
+                        bothtaus.push_back(tau2)
+                        MET_x = event.PuppiMET_pt*math.cos(event.PuppiMET_phi)
+                        MET_y = event.PuppiMET_pt*math.sin(event.PuppiMET_phi)
+                        covMET = ROOT.TMatrixD(2,2)
+                        covMET[0][0] = event.MET_covXX
+                        covMET[1][0] = event.MET_covXY
+                        covMET[0][1] = event.MET_covXY
+                        covMET[1][1] = event.MET_covYY
+                        FMTT = ROOT.FastMTT()
+                        FMTT.run(bothtaus, MET_x, MET_y, covMET)
+                        FMTToutput = FMTT.getBestP4()
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoPt", combgen.Pt())
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoEta", combgen.Eta())
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoPhi", combgen.Phi())
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoMass", FMTToutput.M())
+                        if combgen.M()<1:
+                          for idxX in higgs_gen.dauIdx:
+                             dauX = event.genparts[idxX]
+                    else:
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoPt", -1)
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoEta", -1)
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoPhi", -1)
+                        self.out.fillBranch(f"genHiggs{index_h+1}RecoMass", -1)
+                else:
+                    self.out.fillBranch(f"genHiggs{index_h+1}RecoPt", -1)
+                    self.out.fillBranch(f"genHiggs{index_h+1}RecoEta", -1)
+                    self.out.fillBranch(f"genHiggs{index_h+1}RecoPhi", -1)
+                    self.out.fillBranch(f"genHiggs{index_h+1}RecoMass", -1)
                 for fj in probe_jets:
                     if deltaR(higgs_gen, fj) < 0.8:
                         fj.HiggsMatch = True
@@ -2525,7 +2655,7 @@ class hhh6bProducerPNetAK4(Module):
         index_fj = 0
         for fj in probe_jets:
             index_fj += 1
-            for j in event.ak4jets+event.looseTaus:
+            for j in event.ak4jets+event.looseTaus+event.looseLeptons:
                 if deltaR(fj,j) < 0.8:
                     j.FatJetMatch = True
                     j.FatJetMatchIndex = index_fj
@@ -2545,7 +2675,7 @@ class hhh6bProducerPNetAK4(Module):
                  #"2022EE" : 0.91255}[self.year]
         XtautauWP = 0.9
         self.out.fillBranch("nprobejets", len([fj for fj in probe_jets if fj.pt > 200 and fj.Xbb > XbbWP]))
-        self.out.fillBranch("nprobetaus", len([fj for fj in probe_jets if fj.pt > 200 and fj.Xtautau > XtautauWP]))
+        self.out.fillBranch("nprobetaus", len([fj for fj in probe_jets if fj.pt > 200 and fj.Xtauany > XtautauWP]))
         #print(len(probe_jets))
         #if len(probe_jets) > 0:
         self.fillFatJetInfo(event, probe_jets)
@@ -2554,7 +2684,7 @@ class hhh6bProducerPNetAK4(Module):
         #self.fillJetInfo(event, event.bmjets)
         #self.fillJetInfo(event, event.bljets)
         try:
-            self.fillJetInfo(event, event.ak4jets, probe_jets, XbbWP, event.looseTaus, XtautauWP)
+            self.fillJetInfo(event, event.ak4jets, probe_jets, XbbWP, event.looseTaus, XtautauWP, event.looseLeptons)
         except IndexError:
             return False
 


### PR DESCRIPTION
When manually reconstructing Higgs boson (changes in `higgsPairingAlgorithm_v2.py`)
- Select leptons as well, and mix them with Taus to reconstruct leptonic decay from Htautau
    - For resolved, it's obvious. For Htautau FatJet, it's based on what the highest PNet AK8 score is between tau-tau, mu-tau and e-tau
- Apply various cuts and tighter object selection only when manually reconstructing Higgs bosons:
    - Consider leptons (for leptonic HTauTau) not overlapping with FatJets
    - Consider (hadronic) Taus passing given DeepTau WPs and not overlapping with FatJets and previously selected leptons
    - Consider AK4 jets passing given PNet b-tagging WP and not overlapping with FatJets and previously selected taus (Note that generally, in `hhh6bProducerPNetAK4`, jets are already cleaned from leptons beforehand)
- Add a flag to use different algorithm to select which permutation of available object to use: Based on invariant masses closest to expected Higgs mass as a function of the reconstructed Higgs pT
- Minor other changes

Main postprocessing module `hhh6bProducerPNetAK4`:
- Adding more branches:
    - Removal of AK4 contamination in AK8: n3b1 and Tau21
    - h1/2/3_match variable changed from bool to int (which GenHiggs it's matched to)
    - Additional branch that says what the final state of the reconstructed Htautau is
    - Store up to 4 leptons (instead of 2)
    - Include charge and mass of leptons, and Higgs/FatJetMatch variables
    - Reconstructed variables of objects matched to GenHiggs
    - Variables of GenHiggs daughters
- Hardcode true electron/muon mass to electron/muon objects (required by FastMTT)
- Loosen DeepTau WP cuts to pass only loosest WPs
- AK4 jets must only pass tight jetID instead of tight+leptonVeto, and must not pass PNet b-tagger at this point
    - Manual lepton veto is applied instead using selected leptons
- Find leptons genmatched to GenHiggs daughters
- Minor other changes/fixes

One more thing I still wanted to add, which I haven't yet at this point, is an option (can be turned on/off with a hardcoded flag) to attempt to remove jets from the FatJet collection, not passing certain cuts on n3b1 and Tau21, and consider those as AK4 jets instead